### PR TITLE
Adding interface definition for registered IOs

### DIFF
--- a/ARCH/openfpga_arch_template/k4_N8_reset_softadder_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
+++ b/ARCH/openfpga_arch_template/k4_N8_reset_softadder_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
@@ -129,20 +129,56 @@
       <wire_param model_type="pi" R="0" C="0" num_level="1"/>
       <!-- model_type could be T, res_val cap_val should be defined -->
     </circuit_model>
-    <circuit_model type="mux" name="mux_tree" prefix="mux_tree" is_default="true" dump_structural_verilog="true">
-      <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
+    <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1" local_encoder="true"/>
       <input_buffer exist="false"/>
-      <output_buffer exist="false"/>
-      <pass_gate_logic circuit_model_name="sky130_fd_sc_hd__mux2_1"/>
+      <output_buffer exist="true" circuit_model_name="sky130_fd_sc_hd__buf_1"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
       <port type="sram" prefix="sram" size="1"/>
     </circuit_model>
-    <circuit_model type="mux" name="mux_tree_tapbuf" prefix="mux_tree_tapbuf" dump_structural_verilog="true">
-      <design_technology type="cmos" structure="tree" add_const_input="true" const_input_val="1"/>
+    <circuit_model type="mux" name="mux_2level_tapbuf4" prefix="mux_2level_tapbuf4" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1" local_encoder="true"/>
       <input_buffer exist="false"/>
       <output_buffer exist="true" circuit_model_name="sky130_fd_sc_hd__buf_4"/>
-      <pass_gate_logic circuit_model_name="sky130_fd_sc_hd__mux2_1"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="1"/>
+    </circuit_model>
+    <circuit_model type="mux" name="mux_2level_tapbuf8" prefix="mux_2level_tapbuf8" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1" local_encoder="true"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="true" circuit_model_name="sky130_fd_sc_hd__buf_8"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="1"/>
+    </circuit_model>
+    <circuit_model type="mux" name="mux_2level_tapbuf16" prefix="mux_2level_tapbuf16" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1" local_encoder="true"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="true" circuit_model_name="sky130_fd_sc_hd__buf_16"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="1"/>
+    </circuit_model>
+    <circuit_model type="mux" name="mux_1level" is_default="true" prefix="mux_1level" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="multi_level" num_level="1" add_const_input="true" const_input_val="1" local_encoder="true"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="true" circuit_model_name="sky130_fd_sc_hd__inv_1"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="1"/>
+    </circuit_model>
+    <circuit_model type="mux" name="mux_1level_tapbuf" prefix="mux_1level_tapbuf" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="multi_level" num_level="1" add_const_input="true" const_input_val="1" local_encoder="true"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="true" circuit_model_name="sky130_fd_sc_hd__inv_4"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
       <port type="input" prefix="in" size="1"/>
       <port type="output" prefix="out" size="1"/>
       <port type="sram" prefix="sram" size="1"/>
@@ -210,12 +246,12 @@
     <organization type="scan_chain" circuit_model_name="sky130_fd_sc_hd__dfrtp_1" num_regions="1"/>
   </configuration_protocol>
   <connection_block>
-    <switch name="ipin_cblock" circuit_model_name="mux_tree_tapbuf"/>
+    <switch name="ipin_cblock" circuit_model_name="mux_2level"/>
   </connection_block>
   <switch_block>
-    <switch name="L1_mux" circuit_model_name="mux_tree_tapbuf"/>
-    <switch name="L2_mux" circuit_model_name="mux_tree_tapbuf"/>
-    <switch name="L4_mux" circuit_model_name="mux_tree_tapbuf"/>
+    <switch name="L1_mux" circuit_model_name="mux_2level_tapbuf4"/>
+    <switch name="L2_mux" circuit_model_name="mux_2level_tapbuf8"/>
+    <switch name="L4_mux" circuit_model_name="mux_2level_tapbuf16"/>
   </switch_block>
   <routing_segment>
     <segment name="L1" circuit_model_name="chan_segment"/>
@@ -235,9 +271,17 @@
     <!-- physical pb_type binding in complex block IO -->
     <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
     <!-- IMPORTANT: must set unused I/Os to operating in INPUT mode !!! -->
-    <pb_type name="io[physical].iopad" circuit_model_name="EMBEDDED_IO_HD" mode_bits="1"/> 
-    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
-    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <pb_type name="io[physical].iopad">
+      <interconnect name="mux1" circuit_model_name="mux_1level"/>
+      <interconnect name="mux2" circuit_model_name="mux_1level"/>
+    </pb_type>
+    <pb_type name="io[physical].iopad.pad" circuit_model_name="EMBEDDED_IO_HD" mode_bits="1"/> 
+    <pb_type name="io[io_input].io_input.inpad" physical_pb_type_name="io[physical].iopad.pad" mode_bits="1"/>
+    <pb_type name="io[io_output].io_output.outpad" physical_pb_type_name="io[physical].iopad.pad" mode_bits="0"/>
+
+    <pb_type name="io[physical].iopad.ff" circuit_model_name="sky130_fd_sc_hd__sdfrtp_1"/>
+    <pb_type name="io[io_input].io_input.ff" physical_pb_type_name="io[physical].iopad.ff"/>
+    <pb_type name="io[io_output].io_output.ff" physical_pb_type_name="io[physical].iopad.ff"/>
     <!-- End physical pb_type binding in complex block IO -->
 
     <!-- physical pb_type binding in complex block CLB -->

--- a/ARCH/vpr_arch/k4_N8_tileable_reset_softadder_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
+++ b/ARCH/vpr_arch/k4_N8_tileable_reset_softadder_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
@@ -25,51 +25,17 @@
   -->
   <models>
     <!-- A virtual model for I/O to be used in the physical mode of io block -->
-    <model name="io">
+    <!--model name="io">
       <input_ports>
         <port name="outpad"/>
       </input_ports>
       <output_ports>
         <port name="inpad"/>
       </output_ports>
-    </model>
-    <model name="in_buff">
-      <input_ports>
-        <port name="A" combinational_sink_ports="Q"/>
-      </input_ports>
-      <output_ports>
-        <port name="Q"/>
-      </output_ports>
-    </model>
-    <model name="in_reg">
-      <input_ports>
-        <port name="clk" is_clock="1"/>
-        <port name="dataIn" clock="clk"/>
-      </input_ports>
-      <output_ports>
-        <port name="dataOut" clock="clk"/>
-      </output_ports>
-    </model>
-    <model name="out_buff">
-      <input_ports>
-        <port combinational_sink_ports="Q" name="A"/>
-      </input_ports>
-      <output_ports>
-        <port name="Q"/>
-      </output_ports>
-    </model>
-    <model name="out_reg">
-      <input_ports>
-        <port name="clk" is_clock="1"/>
-        <port name="dataIn" clock="clk"/>
-      </input_ports>
-      <output_ports>
-        <port name="dataOut" clock="clk"/>
-      </output_ports>
-    </model>
+    </mode-->
     <model name="intf_model">
       <input_ports>
-        <port name="CLK" is_clock="1"/>
+        <port name="clk" is_clock="1"/>
         <port name="SOC_IN" clock="clk"/>
         <port name="FPGA_OUT" clock="clk"/>
       </input_ports>
@@ -120,15 +86,14 @@
       <equivalent_sites>
         <site pb_type="interface"/>
       </equivalent_sites>
-      <clock name="CLK" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
       <input name="SOC_IN" num_pins="1"/>
       <input name="FPGA_OUT" num_pins="1"/>
       <output name="FPGA_IN" num_pins="1"/>
       <output name="SOC_OUT" num_pins="1"/>
       <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
       <pinlocations pattern="custom">
-        <loc side="bottom">io_top.FPGA_IN io_top.FPGA_OUT</loc>
-        <loc side="top">io_top.SOC_IN io_top.SOC_OUT io_top.CLK</loc>
+        <loc side="bottom">io_top.FPGA_IN io_top.FPGA_OUT io_top.SOC_IN io_top.SOC_OUT io_top.clk</loc>
       </pinlocations>
     </tile>
     <!-- Right-side has 1 I/O per tile -->
@@ -136,15 +101,14 @@
       <equivalent_sites>
         <site pb_type="interface"/>
       </equivalent_sites>
-      <clock name="CLK" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
       <input name="SOC_IN" num_pins="1"/>
       <input name="FPGA_OUT" num_pins="1"/>
       <output name="FPGA_IN" num_pins="1"/>
       <output name="SOC_OUT" num_pins="1"/>
       <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
       <pinlocations pattern="custom">
-        <loc side="bottom">io_right.FPGA_IN io_right.FPGA_OUT</loc>
-        <loc side="top">io_right.SOC_IN io_right.SOC_OUT io_right.CLK</loc>
+        <loc side="left">io_right.FPGA_IN io_right.FPGA_OUT io_right.SOC_IN io_right.SOC_OUT io_right.clk</loc>
       </pinlocations>
     </tile>
     <!-- Bottom-side has 9 I/O per tile -->
@@ -152,15 +116,14 @@
       <equivalent_sites>
         <site pb_type="interface"/>
       </equivalent_sites>
-      <clock name="CLK" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
       <input name="SOC_IN" num_pins="1"/>
       <input name="FPGA_OUT" num_pins="1"/>
       <output name="FPGA_IN" num_pins="1"/>
       <output name="SOC_OUT" num_pins="1"/>
       <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
       <pinlocations pattern="custom">
-        <loc side="top">io_bottom.FPGA_IN io_bottom.FPGA_OUT</loc>
-        <loc side="bottom">io_bottom.SOC_IN io_bottom.SOC_OUT io_bottom.CLK</loc>
+        <loc side="top">io_bottom.FPGA_IN io_bottom.FPGA_OUT io_bottom.SOC_IN io_bottom.SOC_OUT io_bottom.clk</loc>
       </pinlocations>
     </tile>
     <!-- Left-side has 1 I/O per tile -->
@@ -168,15 +131,14 @@
       <equivalent_sites>
         <site pb_type="interface"/>
       </equivalent_sites>
-      <clock name="CLK" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
       <input name="SOC_IN" num_pins="1"/>
       <input name="FPGA_OUT" num_pins="1"/>
       <output name="FPGA_IN" num_pins="1"/>
       <output name="SOC_OUT" num_pins="1"/>
       <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
       <pinlocations pattern="custom">
-        <loc side="right">io_left.FPGA_IN io_left.FPGA_OUT</loc>
-        <loc side="left">io_left.SOC_IN io_left.SOC_OUT io_left.CLK</loc>
+        <loc side="right">io_left.FPGA_IN io_left.FPGA_OUT io_left.SOC_IN io_left.SOC_OUT io_left.clk</loc>
       </pinlocations>
     </tile>
     <!-- CLB has most pins on the top and right sides -->
@@ -333,8 +295,8 @@
   </directlist>
   <complexblocklist>
     <!-- Define I/O pads begins -->
-    <pb_type name="interface" num_pins="1">
-      <clock name="CLK" num_pins="1"/>
+    <pb_type name="interface">
+      <clock name="clk" num_pins="1"/>
       <input name="SOC_IN" num_pins="1"/>
       <input name="FPGA_OUT" num_pins="1"/>
       <output name="FPGA_IN" num_pins="1"/>
@@ -342,14 +304,18 @@
       <!-- Physical mode definition begin (physical implementation of the interface) -->
       <mode name="physical" disabled_in_pack="true">
           <pb_type name="intf_fabric" blif_model=".subckt intf_model" num_pb="1">
-            <clock name="CLK" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
             <input name="SOC_IN" num_pins="1"/>
             <input name="FPGA_OUT" num_pins="1"/>
             <output name="FPGA_IN" num_pins="1"/>
             <output name="SOC_OUT" num_pins="1"/>
+            <T_setup value="66e-12" port="intf_fabric.SOC_IN" clock="clk"/>
+            <T_setup value="66e-12" port="intf_fabric.FPGA_OUT" clock="clk"/>
+            <T_clock_to_Q max="124e-12" port="intf_fabric.FPGA_IN" clock="clk"/>
+            <T_clock_to_Q max="124e-12" port="intf_fabric.SOC_OUT" clock="clk"/>
           </pb_type>
           <interconnect>
-            <direct name="direct1" input="interface.CLK" output="intf_fabric.CLK"/>
+            <direct name="direct1" input="interface.clk" output="intf_fabric.clk"/>
             <direct name="direct2" input="interface.SOC_IN" output="intf_fabric.SOC_IN"/>
             <direct name="direct3" input="interface.FPGA_OUT" output="intf_fabric.FPGA_OUT"/>
             <direct name="direct4" input="intf_fabric.FPGA_IN" output="interface.FPGA_IN"/>
@@ -357,120 +323,68 @@
           </interconnect>
       </mode>
       <!-- Physical mode definition end (physical implementation of the interface) -->
-      <mode name="in_buff">
-        <pb_type name="in_buff" num_pb="1">
-          <clock name="CLK" num_pins="1"/>
+      <mode name="io_input">
+        <pb_type name="io_input" num_pb="1">
+          <clock name="clk" num_pins="1"/>
           <input name="SOC_IN" num_pins="1"/>
           <output name="FPGA_IN" num_pins="1"/>
-          <pb_type blif_model=".input" name="inpad" num_pb="1">
+          <pb_type name="inpad" blif_model=".input" num_pb="1">
             <output name="inpad" num_pins="1"/>
           </pb_type>
-          <pb_type blif_model=".subckt in_buff" name="inst_buff" num_pb="1">
-            <input name="A" num_pins="1"/>
-            <output name="Q" num_pins="1"/>
-            <delay_constant in_port="inst_buff.A" max="1e-10" out_port="inst_buff.Q"/>
-            <!--metadata>
-              <meta name="fasm_features">ISEL</meta>
-            </metadata-->
+          <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+            <input name="D" num_pins="1" port_class="D"/>
+            <output name="Q" num_pins="1" port_class="Q"/>
+            <clock name="clk" num_pins="1" port_class="clock"/>
+            <T_setup value="66e-12" port="ff.D" clock="clk"/>
+            <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
           </pb_type>
           <interconnect>
-            <direct input="inst_buff.Q" name="in_buff-FPGA_IN" output="in_buff.FPGA_IN">
-            <direct input="inpad.inpad" name="inst_buff-A" output="inst_buff.A">
-              <pack_pattern in_port="inpad.inpad" name="pack-IPAD_TO_IBUF" out_port="inst_buff.A"/>
+            <direct name="io_input-FPGA_IN" input="inpad.inpad" output="io_input.FPGA_IN">
+              <pack_pattern name="pack-IPAD_TO_IBUF" in_port="inpad.inpad" out_port="io_input.FPGA_IN"/>
+            </direct>
+            <direct name="ff-clk" input="io_input.clk" output="ff.clk"/>
+            <direct name="ff-Q" input="ff.Q" output="io_input.FPGA_IN" />
+            <direct name="ff-D" input="inpad.inpad" output="ff.D">
+              <pack_pattern name="pack-IPAD_TO_IREG" in_port="inpad.inpad" out_port="ff.D"/>
             </direct>
           </interconnect>
         </pb_type>
         <interconnect>
-          <direct input="in_buff.FPGA_IN" name="interface-FPGA_IN" output="interface.FPGA_IN"/>
-          <direct input="interface.SOC_IN" name="in_buff-SOC_IN" output="in_buff.SOC_IN"/>
-          <direct input="interface.CLK" name="in_buff-CLK" output="in_buff.CLK"/>
+          <direct name="interface-FPGA_IN" input="io_input.FPGA_IN" output="interface.FPGA_IN"/>
+          <direct name="io_input-SOC_IN" input="interface.SOC_IN" output="io_input.SOC_IN"/>
+          <direct name="io_input-clk" input="interface.clk" output="io_input.clk"/>
         </interconnect>
       </mode>
-      <mode name="out_buff">
-        <pb_type name="out_buff" num_pb="1">
-          <clock name="CLK" num_pins="1"/>
+      <mode name="io_output">
+        <pb_type name="io_output" num_pb="1">
+          <clock name="clk" num_pins="1"/>
           <input name="FPGA_OUT" num_pins="1"/>
           <output name="SOC_OUT" num_pins="1"/>
-          <pb_type blif_model=".subckt out_buff" name="inst_buff" num_pb="1">
-            <input name="A" num_pins="1"/>
-            <output name="Q" num_pins="1"/>
-            <delay_constant in_port="inst_buff.A" max="1e-10" out_port="inst_buff.Q"/>
-            <!--metadata>
-              <meta name="fasm_features">OSEL</meta>
-            </metadata-->
+          <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+            <input name="D" num_pins="1" port_class="D"/>
+            <output name="Q" num_pins="1" port_class="Q"/>
+            <clock name="clk" num_pins="1" port_class="clock"/>
+            <T_setup value="66e-12" port="ff.D" clock="clk"/>
+            <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
           </pb_type>
-          <pb_type blif_model=".output" name="outpad" num_pb="1">
+          <pb_type name="outpad" blif_model=".output" num_pb="1">
             <input name="outpad" num_pins="1"/>
           </pb_type>
           <interconnect>
-            <direct input="out_buff.FPGA_OUT" name="inst_buff-A" output="inst_buff.A"/>
-            <direct input="inst_buff.Q" name="outpad-outpad" output="outpad.outpad">
-              <pack_pattern in_port="inst_buff.Q" name="pack-OBUF_TO_OPAD" out_port="outpad.outpad"/>
+            <direct name="io_output-FPGA_OUT" input="io_output.FPGA_OUT" output="outpad.outpad">
+              <pack_pattern name="pack-OBUF_TO_OPAD" in_port="io_output.FPGA_OUT" out_port="outpad.outpad"/>
+            </direct>
+            <direct name="ff-clk" input="io_output.clk" output="ff.clk"/>
+            <direct name="ff-D" input="io_output.FPGA_OUT" output="ff.D"/>
+            <direct name="outpad-outpad" input="ff.Q" output="outpad.outpad">
+              <pack_pattern name="pack-OBUF_TO_OREG" in_port="ff.Q" out_port="outpad.outpad"/>
             </direct>
           </interconnect>
         </pb_type>
         <interconnect>
-          <direct input="out_buff.SOC_OUT" name="interface-SOC_OUT" output="interface.SOC_OUT"/>
-          <direct input="interface.CLK" name="out_buff-CLK" output="out_buff.CLK"/>
-          <direct input="interface.FPGA_OUT" name="out_buff-FPGA_OUT" output="out_buff.FPGA_OUT"/>
-        </interconnect>
-      </mode>
-      <mode name="in_reg">
-        <pb_type name="in_reg" num_pb="1">
-          <clock name="CLK" num_pins="1"/>
-          <input name="SOC_IN" num_pins="1"/>
-          <output name="FPGA_IN" num_pins="1"/>
-          <pb_type blif_model=".input" name="inpad" num_pb="1">
-            <output name="inpad" num_pins="1"/>
-          </pb_type>
-          <pb_type blif_model=".subckt in_reg" name="inst_reg" num_pb="1">
-            <clock name="clk" num_pins="1"/>
-            <input name="dataIn" num_pins="1"/>
-            <output name="dataOut" num_pins="1"/>
-            <T_setup clock="clk" port="inst_reg.dataIn" value="1e-10"/>
-            <T_clock_to_Q clock="clk" max="1e-10" port="inst_reg.dataOut"/>
-          </pb_type>
-          <interconnect>
-            <direct input="inst_reg.dataOut" name="in_reg-FPGA_IN" output="in_reg.FPGA_IN"/>
-            <direct input="in_reg.CLK" name="inst_reg-clk" output="inst_reg.clk"/>
-            <direct input="inpad.inpad" name="inst_reg-dataIn" output="inst_reg.dataIn">
-              <pack_pattern in_port="inpad.inpad" name="pack-IPAD_TO_IREG" out_port="inst_reg.dataIn"/>
-            </direct>
-          </interconnect>
-          </pb_type>
-          <interconnect>
-          <direct input="in_reg.FPGA_IN" name="interface-FPGA_IN" output="interface.FPGA_IN"/>
-          <direct input="interface.SOC_IN" name="in_reg-SOC_IN" output="in_reg.SOC_IN"/>
-          <direct input="interface.CLK" name="in_reg-CLK" output="in_reg.CLK"/>
-          </interconnect>
-      </mode>
-      <mode name="out_reg">
-        <pb_type name="out_reg" num_pb="1">
-          <clock name="CLK" num_pins="1"/>
-          <input name="FPGA_OUT" num_pins="1"/>
-          <output name="SOC_OUT" num_pins="1"/>
-          <pb_type blif_model=".subckt out_reg" name="inst_reg" num_pb="1">
-            <clock name="clk" num_pins="1"/>
-            <input name="dataIn" num_pins="1"/>
-            <output name="dataOut" num_pins="1"/>
-            <T_setup clock="clk" port="inst_reg.dataIn" value="1e-10"/>
-            <T_clock_to_Q clock="clk" max="1e-10" port="inst_reg.dataOut"/>
-          </pb_type>
-          <pb_type blif_model=".output" name="outpad" num_pb="1">
-            <input name="outpad" num_pins="1"/>
-          </pb_type>
-          <interconnect>
-            <direct input="out_reg.CLK" name="inst_reg-clk" output="inst_reg.clk"/>
-            <direct input="out_reg.FPGA_OUT" name="inst_reg-dataIn" output="inst_reg.dataIn"/>
-            <direct input="inst_reg.dataOut" name="outpad-outpad" output="outpad.outpad">
-              <pack_pattern in_port="inst_reg.dataOut" name="pack-OBUF_TO_OREG" out_port="outpad.outpad"/>
-            </direct>
-          </interconnect>
-        </pb_type>
-        <interconnect>
-          <direct input="out_reg.SOC_OUT" name="interface-SOC_OUT" output="interface.SOC_OUT"/>
-          <direct input="interface.CLK" name="out_reg-CLK" output="out_reg.CLK"/>
-          <direct input="interface.FPGA_OUT" name="out_reg-FPGA_OUT" output="out_reg.FPGA_OUT"/>
+          <direct input="io_output.SOC_OUT" name="interface-SOC_OUT" output="interface.SOC_OUT"/>
+          <direct input="interface.clk" name="io_output-clk" output="io_output.clk"/>
+          <direct input="interface.FPGA_OUT" name="io_output-FPGA_OUT" output="io_output.FPGA_OUT"/>
         </interconnect>
       </mode>
     </pb_type>

--- a/ARCH/vpr_arch/k4_N8_tileable_reset_softadder_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
+++ b/ARCH/vpr_arch/k4_N8_tileable_reset_softadder_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
@@ -25,6 +25,14 @@ Authors: Xifan Tang
     -->
     <models>
         <!-- A virtual model for I/O to be used in the physical mode of io block -->
+        <model name="io">
+          <input_ports>
+            <port name="outpad"/>
+          </input_ports>
+          <output_ports>
+            <port name="inpad"/>
+          </output_ports>
+        </model>
         <model name="frac_lut4">
             <input_ports>
                 <port name="in"/>
@@ -297,13 +305,17 @@ Authors: Xifan Tang
                         <T_setup value="66e-12" port="ff.D" clock="clk"/>
                         <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
                     </pb_type>
+                    <pb_type name="pad" blif_model=".subckt io" num_pb="1">
+                      <input name="outpad" num_pins="1"/>
+                      <output name="inpad" num_pins="1"/>
+                    </pb_type>
                     <interconnect>
                         <direct name="ff[0:0]-clk" input="iopad.clk" output="ff[0:0].clk"/>
                         <direct name="ff[1:1]-clk" input="iopad.clk" output="ff[1:1].clk"/>
                         <direct name="ff[0:0]-D" input="iopad.f2a_i" output="ff[0:0].D" />
                         <direct name="ff[1:1]-D" input="iopad.a2f_i" output="ff[1:1].D" />
-                        <mux name="mux1" input="iopad.f2a_i ff[0:0].Q" output="iopad.f2a_o"/>
-                        <mux name="mux2" input="iopad.a2f_i ff[1:1].Q" output="iopad.a2f_o"/>
+                        <mux name="mux1" input="iopad.f2a_i ff[0:0].Q" output="pad.outpad"/>
+                        <mux name="mux2" input="pad.inpad ff[1:1].Q" output="iopad.a2f_o"/>
                     </interconnect>
                 </pb_type>
                 <interconnect>
@@ -319,7 +331,6 @@ Authors: Xifan Tang
                 <pb_type name="io_output" num_pb="1">
                     <clock name="clk" num_pins="1"/>
                     <input name="f2a_i" num_pins="1"/>
-                    <output name="f2a_o" num_pins="1"/>
                     <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
                         <input name="D" num_pins="1" port_class="D"/>
                         <output name="Q" num_pins="1" port_class="Q"/>
@@ -338,13 +349,9 @@ Authors: Xifan Tang
                             <delay_constant max="25e-12" in_port="io_output.f2a_i" out_port="outpad.outpad"/>
                             <delay_constant max="45e-12" in_port="ff.Q" out_port="outpad.outpad"/>
                         </mux>
-                        <!--direct name="outpad" input="io_output.f2a_i" output="outpad.outpad">
-                            <delay_constant max="1.394e-11" in_port="io_output.f2a_i" out_port="outpad.outpad"/>
-                        </direct-->
                     </interconnect>
                 </pb_type>
                 <interconnect>
-                    <direct name="io-f2a_o" input="io_output.f2a_o" output="io.f2a_o"/>
                     <direct name="io_output-clk" input="io.clk" output="io_output.clk"/>
                     <direct name="io_output-f2a_i" input="io.f2a_i" output="io_output.f2a_i"/>
                 </interconnect>
@@ -352,7 +359,6 @@ Authors: Xifan Tang
             <mode name="io_input">
                 <pb_type name="io_input" num_pb="1">
                     <clock name="clk" num_pins="1"/>
-                    <input name="a2f_i" num_pins="1"/>
                     <output name="a2f_o" num_pins="1"/>
                     <pb_type name="inpad" blif_model=".input" num_pb="1">
                         <output name="inpad" num_pins="1"/>
@@ -366,20 +372,16 @@ Authors: Xifan Tang
                     </pb_type>
                     <interconnect>
                         <direct name="ff-clk" input="io_input.clk" output="ff.clk"/>
-                        <direct name="ff-D" input="io_input.a2f_i" output="ff.D"/>
-                        <mux name="mux2" input="io_input.a2f_i ff.Q" output="io_input.a2f_o">
+                        <direct name="ff-D" input="inpad.inpad" output="ff.D"/>
+                        <mux name="mux2" input="inpad.inpad ff.Q" output="io_input.a2f_o">
                             <pack_pattern name="pack-IREG" in_port="ff.Q" out_port="io_input.a2f_o"/>
-                            <delay_constant max="25e-12" in_port="io_input.a2f_i" out_port="io_input.a2f_o"/>
+                            <delay_constant max="25e-12" in_port="inpad.inpad" out_port="io_input.a2f_o"/>
                             <delay_constant max="45e-12" in_port="ff.Q" out_port="io_input.a2f_o"/>
                         </mux>
-                        <direct name="inpad" input="inpad.inpad" output="io_input.a2f_o">
-                            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io_input.a2f_o"/>
-                        </direct>
                     </interconnect>
                 </pb_type>
                 <interconnect>
                     <direct name="io-a2f_o" input="io_input.a2f_o" output="io.a2f_o"/>
-                    <direct name="io_input-a2f_i" input="io.a2f_i" output="io_input.a2f_i"/>
                     <direct name="io_input-clk" input="io.clk" output="io_input.clk"/>
                 </interconnect>
             </mode>

--- a/ARCH/vpr_arch/k4_N8_tileable_reset_softadder_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
+++ b/ARCH/vpr_arch/k4_N8_tileable_reset_softadder_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
@@ -166,7 +166,7 @@ Authors: Xifan Tang
             <col type="io_left" startx="0" priority="100"/>
             <col type="io_right" startx="W-1" priority="100"/>
             <corners type="EMPTY" priority="101"/>
-                <!--Fill with 'clb'-->
+            <!--Fill with 'clb'-->
             <fill type="clb" priority="10"/>
         </auto_layout>
         <fixed_layout name="2x2" width="4" height="4">
@@ -176,7 +176,7 @@ Authors: Xifan Tang
             <col type="io_left" startx="0" priority="100"/>
             <col type="io_right" startx="W-1" priority="100"/>
             <corners type="EMPTY" priority="101"/>
-                <!--Fill with 'clb'-->
+            <!--Fill with 'clb'-->
             <fill type="clb" priority="10"/>
         </fixed_layout>
         <fixed_layout name="12x12" width="14" height="14">
@@ -186,7 +186,7 @@ Authors: Xifan Tang
             <col type="io_left" startx="0" priority="100"/>
             <col type="io_right" startx="W-1" priority="100"/>
             <corners type="EMPTY" priority="101"/>
-                <!--Fill with 'clb'-->
+            <!--Fill with 'clb'-->
             <fill type="clb" priority="10"/>
         </fixed_layout>
         <fixed_layout name="32x32" width="34" height="34">
@@ -196,7 +196,7 @@ Authors: Xifan Tang
             <col type="io_left" startx="0" priority="100"/>
             <col type="io_right" startx="W-1" priority="100"/>
             <corners type="EMPTY" priority="101"/>
-                <!--Fill with 'clb'-->
+            <!--Fill with 'clb'-->
             <fill type="clb" priority="10"/>
         </fixed_layout>
     </layout>
@@ -217,9 +217,9 @@ Authors: Xifan Tang
             C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
         4x minimum drive strength buffer. -->
         <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
-            <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
-                area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-            -->
+        <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+            area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
+        -->
         <area grid_logic_tile_area="0"/>
         <chan_width_distr>
             <x distr="uniform" peak="1.000000"/>
@@ -245,7 +245,7 @@ Authors: Xifan Tang
         <switch type="mux" name="L1_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
         <switch type="mux" name="L2_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
         <switch type="mux" name="L4_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
-            <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+        <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
         <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
     </switchlist>
     <segmentlist>
@@ -278,19 +278,19 @@ Authors: Xifan Tang
         <!-- Define I/O pads begins -->
         <pb_type name="io">
             <clock name="clk" num_pins="1"/>
-            <input name="SOC_IN" num_pins="1"/>
-            <input name="FPGA_OUT" num_pins="1"/>
-            <output name="FPGA_IN" num_pins="1"/>
-            <output name="SOC_OUT" num_pins="1"/>
-                <!-- Physical mode definition begin (physical implementation of the io) -->
+            <input name="a2f_i" num_pins="1"/> <!--SOC_IN-->
+            <input name="f2a_i" num_pins="1"/> <!--FPGA_OUT-->
+            <output name="a2f_o" num_pins="1"/> <!--FPGA_IN-->
+            <output name="f2a_o" num_pins="1"/> <!--SOC_OUT-->
+            <!-- Physical mode definition begin (physical implementation of the io) -->
             <mode name="physical" disabled_in_pack="true">
-                <pb_type name="intf_fabric" num_pb="1">
+                <pb_type name="iopad" num_pb="1">
                     <clock name="clk" num_pins="1"/>
-                    <input name="SOC_IN" num_pins="1"/>
-                    <input name="FPGA_OUT" num_pins="1"/>
-                    <output name="FPGA_IN" num_pins="1"/>
-                    <output name="SOC_OUT" num_pins="1"/>
-                    <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                    <input name="a2f_i" num_pins="1"/>
+                    <input name="f2a_i" num_pins="1"/>
+                    <output name="a2f_o" num_pins="1"/>
+                    <output name="f2a_o" num_pins="1"/>
+                    <pb_type name="ff" blif_model=".latch" num_pb="2" class="flipflop">
                         <input name="D" num_pins="1" port_class="D"/>
                         <output name="Q" num_pins="1" port_class="Q"/>
                         <clock name="clk" num_pins="1" port_class="clock"/>
@@ -298,56 +298,28 @@ Authors: Xifan Tang
                         <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
                     </pb_type>
                     <interconnect>
-                        <direct name="ff-clk" input="intf_fabric.clk" output="ff.clk"/>
-                        <mux name="mux1" input="intf_fabric.SOC_IN ff.Q" output="intf_fabric.FPGA_IN"/>
-                        <mux name="mux2" input="intf_fabric.FPGA_OUT ff.Q" output="intf_fabric.SOC_OUT"/>
-                        <mux name="mux3" input="intf_fabric.SOC_IN intf_fabric.FPGA_OUT" output="ff.D"/>
+                        <direct name="ff[0:0]-clk" input="iopad.clk" output="ff[0:0].clk"/>
+                        <direct name="ff[1:1]-clk" input="iopad.clk" output="ff[1:1].clk"/>
+                        <direct name="ff[0:0]-D" input="iopad.f2a_i" output="ff[0:0].D" />
+                        <direct name="ff[1:1]-D" input="iopad.a2f_i" output="ff[1:1].D" />
+                        <mux name="mux1" input="iopad.f2a_i ff[0:0].Q" output="iopad.f2a_o"/>
+                        <mux name="mux2" input="iopad.a2f_i ff[1:1].Q" output="iopad.a2f_o"/>
                     </interconnect>
                 </pb_type>
                 <interconnect>
-                    <direct name="direct1" input="io.clk" output="intf_fabric.clk"/>
-                    <direct name="direct2" input="io.SOC_IN" output="intf_fabric.SOC_IN"/>
-                    <direct name="direct3" input="io.FPGA_OUT" output="intf_fabric.FPGA_OUT"/>
-                    <direct name="direct4" input="intf_fabric.FPGA_IN" output="io.FPGA_IN"/>
-                    <direct name="direct5" input="intf_fabric.SOC_OUT" output="io.SOC_OUT"/>
+                    <direct name="direct1" input="io.clk" output="iopad.clk"/>
+                    <direct name="direct2" input="io.a2f_i" output="iopad.a2f_i"/>
+                    <direct name="direct3" input="io.f2a_i" output="iopad.f2a_i"/>
+                    <direct name="direct4" input="iopad.a2f_o" output="io.a2f_o"/>
+                    <direct name="direct5" input="iopad.f2a_o" output="io.f2a_o"/>
                 </interconnect>
             </mode>
             <!-- Physical mode definition end (physical implementation of the io) -->
-            <mode name="io_input">
-                <pb_type name="io_input" num_pb="1">
-                    <clock name="clk" num_pins="1"/>
-                    <input name="SOC_IN" num_pins="1"/>
-                    <output name="FPGA_IN" num_pins="1"/>
-                    <pb_type name="inpad" blif_model=".input" num_pb="1">
-                        <output name="inpad" num_pins="1"/>
-                    </pb_type>
-                    <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
-                        <input name="D" num_pins="1" port_class="D"/>
-                        <output name="Q" num_pins="1" port_class="Q"/>
-                        <clock name="clk" num_pins="1" port_class="clock"/>
-                        <T_setup value="66e-12" port="ff.D" clock="clk"/>
-                        <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
-                    </pb_type>
-                    <interconnect>
-                        <!--direct name="inpad.inpad" input="io_input.SOC_IN" output="inpad.inpad"/-->
-                        <direct name="ff-clk" input="io_input.clk" output="ff.clk"/>
-                        <direct name="ff-D" input="inpad.inpad" output="ff.D">
-                            <pack_pattern name="pack-IREG" in_port="inpad.inpad" out_port="ff.D"/>
-                        </direct>
-                        <mux name="mux1" input="inpad.inpad ff.Q" output="io_input.FPGA_IN"/>
-                    </interconnect>
-                </pb_type>
-                <interconnect>
-                    <direct name="io-FPGA_IN" input="io_input.FPGA_IN" output="io.FPGA_IN"/>
-                    <direct name="io_input-SOC_IN" input="io.SOC_IN" output="io_input.SOC_IN"/>
-                    <direct name="io_input-clk" input="io.clk" output="io_input.clk"/>
-                </interconnect>
-            </mode>
             <mode name="io_output">
                 <pb_type name="io_output" num_pb="1">
                     <clock name="clk" num_pins="1"/>
-                    <input name="FPGA_OUT" num_pins="1"/>
-                    <output name="SOC_OUT" num_pins="1"/>
+                    <input name="f2a_i" num_pins="1"/>
+                    <output name="f2a_o" num_pins="1"/>
                     <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
                         <input name="D" num_pins="1" port_class="D"/>
                         <output name="Q" num_pins="1" port_class="Q"/>
@@ -360,16 +332,55 @@ Authors: Xifan Tang
                     </pb_type>
                     <interconnect>
                         <direct name="ff-clk" input="io_output.clk" output="ff.clk"/>
-                        <direct name="ff-D" input="io_output.FPGA_OUT" output="ff.D"/>
-                        <mux name="mux2" input="ff.Q io_output.FPGA_OUT" output="outpad.outpad">
+                        <direct name="ff-D" input="io_output.f2a_i" output="ff.D"/>
+                        <mux name="mux1" input="ff.Q io_output.f2a_i" output="outpad.outpad">
                             <pack_pattern name="pack-OREG" in_port="ff.Q" out_port="outpad.outpad"/>
+                            <delay_constant max="25e-12" in_port="io_output.f2a_i" out_port="outpad.outpad"/>
+                            <delay_constant max="45e-12" in_port="ff.Q" out_port="outpad.outpad"/>
                         </mux>
+                        <!--direct name="outpad" input="io_output.f2a_i" output="outpad.outpad">
+                            <delay_constant max="1.394e-11" in_port="io_output.f2a_i" out_port="outpad.outpad"/>
+                        </direct-->
                     </interconnect>
                 </pb_type>
                 <interconnect>
-                    <direct input="io_output.SOC_OUT" name="io-SOC_OUT" output="io.SOC_OUT"/>
-                    <direct input="io.clk" name="io_output-clk" output="io_output.clk"/>
-                    <direct input="io.FPGA_OUT" name="io_output-FPGA_OUT" output="io_output.FPGA_OUT"/>
+                    <direct name="io-f2a_o" input="io_output.f2a_o" output="io.f2a_o"/>
+                    <direct name="io_output-clk" input="io.clk" output="io_output.clk"/>
+                    <direct name="io_output-f2a_i" input="io.f2a_i" output="io_output.f2a_i"/>
+                </interconnect>
+            </mode>
+            <mode name="io_input">
+                <pb_type name="io_input" num_pb="1">
+                    <clock name="clk" num_pins="1"/>
+                    <input name="a2f_i" num_pins="1"/>
+                    <output name="a2f_o" num_pins="1"/>
+                    <pb_type name="inpad" blif_model=".input" num_pb="1">
+                        <output name="inpad" num_pins="1"/>
+                    </pb_type>
+                    <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                        <input name="D" num_pins="1" port_class="D"/>
+                        <output name="Q" num_pins="1" port_class="Q"/>
+                        <clock name="clk" num_pins="1" port_class="clock"/>
+                        <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                        <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+                    </pb_type>
+                    <interconnect>
+                        <direct name="ff-clk" input="io_input.clk" output="ff.clk"/>
+                        <direct name="ff-D" input="io_input.a2f_i" output="ff.D"/>
+                        <mux name="mux2" input="io_input.a2f_i ff.Q" output="io_input.a2f_o">
+                            <pack_pattern name="pack-IREG" in_port="ff.Q" out_port="io_input.a2f_o"/>
+                            <delay_constant max="25e-12" in_port="io_input.a2f_i" out_port="io_input.a2f_o"/>
+                            <delay_constant max="45e-12" in_port="ff.Q" out_port="io_input.a2f_o"/>
+                        </mux>
+                        <direct name="inpad" input="inpad.inpad" output="io_input.a2f_o">
+                            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io_input.a2f_o"/>
+                        </direct>
+                    </interconnect>
+                </pb_type>
+                <interconnect>
+                    <direct name="io-a2f_o" input="io_input.a2f_o" output="io.a2f_o"/>
+                    <direct name="io_input-a2f_i" input="io.a2f_i" output="io_input.a2f_i"/>
+                    <direct name="io_input-clk" input="io.clk" output="io_input.clk"/>
                 </interconnect>
             </mode>
         </pb_type>
@@ -391,10 +402,10 @@ Authors: Xifan Tang
             <output name="sc_out" num_pins="1"/>
             <output name="cout" num_pins="1"/>
             <clock name="clk" num_pins="1"/>
-                <!-- Describe fracturable logic element.  
-                    Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
-                    The outputs of the fracturable logic element can be optionally registered
-                -->
+            <!-- Describe fracturable logic element.  
+                Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
+                The outputs of the fracturable logic element can be optionally registered
+            -->
             <pb_type name="fle" num_pb="8">
                 <input name="in" num_pins="4"/>
                 <input name="reg_in" num_pins="1"/>
@@ -406,7 +417,7 @@ Authors: Xifan Tang
                 <output name="sc_out" num_pins="1"/>
                 <output name="cout" num_pins="1"/>
                 <clock name="clk" num_pins="1"/>
-                    <!-- Physical mode definition begin (physical implementation of the fle) -->
+                <!-- Physical mode definition begin (physical implementation of the fle) -->
                 <mode name="physical" disabled_in_pack="true">
                     <pb_type name="fabric" num_pb="1">
                         <input name="in" num_pins="4"/>
@@ -424,7 +435,7 @@ Authors: Xifan Tang
                             <input name="cin" num_pins="1"/>
                             <output name="out" num_pins="1"/>
                             <output name="cout" num_pins="1"/>
-                                <!-- Define LUT -->
+                            <!-- Define LUT -->
                             <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
                                 <input name="in" num_pins="4"/>
                                 <output name="lut2_out" num_pins="2"/>
@@ -443,7 +454,7 @@ Authors: Xifan Tang
                                 <direct name="direct4" input="frac_lut4.lut2_out[1:1]" output="carry_follower.a"/>
                                 <direct name="direct5" input="frac_lut4.lut2_out[0:0]" output="carry_follower.cin"/>
                                 <direct name="direct6" input="carry_follower.cout" output="frac_logic.cout"/>
-                                    <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
                                 <direct name="direct7" input="frac_lut4.lut4_out" output="frac_logic.out"/>
                                 <mux name="mux2" input="frac_logic.cin frac_logic.in[2:2]" output="frac_lut4.in[2:2]"/>
                             </interconnect>
@@ -499,20 +510,20 @@ Authors: Xifan Tang
                         <input name="in" num_pins="4"/>
                         <output name="out" num_pins="1"/>
                         <clock name="clk" num_pins="1"/>
-                            <!-- Define LUT -->
+                        <!-- Define LUT -->
                         <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
                             <input name="in" num_pins="4" port_class="lut_in"/>
                             <output name="out" num_pins="1" port_class="lut_out"/>
-                                <!-- LUT timing using delay matrix -->
-                                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
-                                    we instead take the average of these numbers to get more stable results
-                                    82e-12
-                                    173e-12
-                                    261e-12
-                                    263e-12
-                                    398e-12
-                                    397e-12
-                                -->
+                            <!-- LUT timing using delay matrix -->
+                            <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                                we instead take the average of these numbers to get more stable results
+                                82e-12
+                                173e-12
+                                261e-12
+                                263e-12
+                                398e-12
+                                397e-12
+                            -->
                             <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
                                 261e-12
                                 261e-12
@@ -601,11 +612,11 @@ Authors: Xifan Tang
                 -->
                 <direct name="clbouts1" input="fle[3:0].out" output="clb.O[3:0]"/>
                 <direct name="clbouts2" input="fle[7:4].out" output="clb.O[7:4]"/>
-                    <!-- Shift register chain links -->
+                <!-- Shift register chain links -->
                 <direct name="shift_register_in" input="clb.reg_in" output="fle[0:0].reg_in">
                     <!-- Put all inter-block carry chain delay on this one edge -->
                     <delay_constant max="0.16e-9" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/>
-                        <!--pack_pattern name="chain" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/-->
+                    <!--pack_pattern name="chain" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/-->
                 </direct>
                 <direct name="shift_register_out" input="fle[7:7].reg_out" output="clb.reg_out">
                     <!--pack_pattern name="chain" in_port="fle[7:7].reg_out" out_port="clb.reg_out"/-->

--- a/ARCH/vpr_arch/k4_N8_tileable_reset_softadder_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
+++ b/ARCH/vpr_arch/k4_N8_tileable_reset_softadder_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
@@ -68,13 +68,13 @@ Authors: Xifan Tang
                 <site pb_type="io"/>
             </equivalent_sites>
             <clock name="clk" num_pins="1"/>
-            <input name="SOC_IN" num_pins="1"/>
-            <input name="FPGA_OUT" num_pins="1"/>
-            <output name="FPGA_IN" num_pins="1"/>
-            <output name="SOC_OUT" num_pins="1"/>
+            <input name="a2f_i" num_pins="1"/>
+            <input name="f2a_i" num_pins="1"/>
+            <output name="a2f_o" num_pins="1"/>
+            <output name="f2a_o" num_pins="1"/>
             <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
             <pinlocations pattern="custom">
-                <loc side="bottom">io_top.FPGA_IN io_top.FPGA_OUT io_top.SOC_IN io_top.SOC_OUT io_top.clk</loc>
+                <loc side="bottom">io_top.a2f_o io_top.f2a_i io_top.a2f_i io_top.f2a_o io_top.clk</loc>
             </pinlocations>
         </tile>
         <!-- Right-side has 1 I/O per tile -->
@@ -83,13 +83,13 @@ Authors: Xifan Tang
                 <site pb_type="io"/>
             </equivalent_sites>
             <clock name="clk" num_pins="1"/>
-            <input name="SOC_IN" num_pins="1"/>
-            <input name="FPGA_OUT" num_pins="1"/>
-            <output name="FPGA_IN" num_pins="1"/>
-            <output name="SOC_OUT" num_pins="1"/>
+            <input name="a2f_i" num_pins="1"/>
+            <input name="f2a_i" num_pins="1"/>
+            <output name="a2f_o" num_pins="1"/>
+            <output name="f2a_o" num_pins="1"/>
             <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
             <pinlocations pattern="custom">
-                <loc side="left">io_right.FPGA_IN io_right.FPGA_OUT io_right.SOC_IN io_right.SOC_OUT io_right.clk</loc>
+                <loc side="left">io_right.a2f_o io_right.f2a_i io_right.a2f_i io_right.f2a_o io_right.clk</loc>
             </pinlocations>
         </tile>
         <!-- Bottom-side has 9 I/O per tile -->
@@ -98,13 +98,13 @@ Authors: Xifan Tang
                 <site pb_type="io"/>
             </equivalent_sites>
             <clock name="clk" num_pins="1"/>
-            <input name="SOC_IN" num_pins="1"/>
-            <input name="FPGA_OUT" num_pins="1"/>
-            <output name="FPGA_IN" num_pins="1"/>
-            <output name="SOC_OUT" num_pins="1"/>
+            <input name="a2f_i" num_pins="1"/>
+            <input name="f2a_i" num_pins="1"/>
+            <output name="a2f_o" num_pins="1"/>
+            <output name="f2a_o" num_pins="1"/>
             <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
             <pinlocations pattern="custom">
-                <loc side="top">io_bottom.FPGA_IN io_bottom.FPGA_OUT io_bottom.SOC_IN io_bottom.SOC_OUT io_bottom.clk</loc>
+                <loc side="top">io_bottom.a2f_o io_bottom.f2a_i io_bottom.a2f_i io_bottom.f2a_o io_bottom.clk</loc>
             </pinlocations>
         </tile>
         <!-- Left-side has 1 I/O per tile -->
@@ -113,13 +113,13 @@ Authors: Xifan Tang
                 <site pb_type="io"/>
             </equivalent_sites>
             <clock name="clk" num_pins="1"/>
-            <input name="SOC_IN" num_pins="1"/>
-            <input name="FPGA_OUT" num_pins="1"/>
-            <output name="FPGA_IN" num_pins="1"/>
-            <output name="SOC_OUT" num_pins="1"/>
+            <input name="a2f_i" num_pins="1"/>
+            <input name="f2a_i" num_pins="1"/>
+            <output name="a2f_o" num_pins="1"/>
+            <output name="f2a_o" num_pins="1"/>
             <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
             <pinlocations pattern="custom">
-                <loc side="right">io_left.FPGA_IN io_left.FPGA_OUT io_left.SOC_IN io_left.SOC_OUT io_left.clk</loc>
+                <loc side="right">io_left.a2f_o io_left.f2a_i io_left.a2f_i io_left.f2a_o io_left.clk</loc>
             </pinlocations>
         </tile>
         <!-- CLB has most pins on the top and right sides -->
@@ -278,10 +278,10 @@ Authors: Xifan Tang
         <!-- Define I/O pads begins -->
         <pb_type name="io">
             <clock name="clk" num_pins="1"/>
-            <input name="a2f_i" num_pins="1"/> <!--SOC_IN-->
-            <input name="f2a_i" num_pins="1"/> <!--FPGA_OUT-->
-            <output name="a2f_o" num_pins="1"/> <!--FPGA_IN-->
-            <output name="f2a_o" num_pins="1"/> <!--SOC_OUT-->
+            <input name="a2f_i" num_pins="1"/> 
+            <input name="f2a_i" num_pins="1"/> 
+            <output name="a2f_o" num_pins="1"/>
+            <output name="f2a_o" num_pins="1"/>
             <!-- Physical mode definition begin (physical implementation of the io) -->
             <mode name="physical" disabled_in_pack="true">
                 <pb_type name="iopad" num_pb="1">

--- a/ARCH/vpr_arch/k4_N8_tileable_reset_softadder_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
+++ b/ARCH/vpr_arch/k4_N8_tileable_reset_softadder_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
@@ -1,655 +1,640 @@
 <!-- 
-  Low-cost homogeneous FPGA Architecture.
+Low-cost homogeneous FPGA Architecture.
 
-  - Skywater 130 nm technology
-  - General purpose logic block: 
-    K = 4, N = 8, fracturable 4 LUTs (can operate as one 4-LUT or two 3-LUTs with all 3 inputs shared) 
-    with optionally registered outputs
-  - Routing architecture:
-      - 10% L = 1, fc_in = 0.15, Fc_out = 0.10
-      - 10% L = 2, fc_in = 0.15, Fc_out = 0.10
-      - 80% L = 4, fc_in = 0.15, Fc_out = 0.10
-      - 100 routing tracks per channel
+- Skywater 130 nm technology
+- General purpose logic block: 
+K = 4, N = 8, fracturable 4 LUTs (can operate as one 4-LUT or two 3-LUTs with all 3 inputs shared) 
+with optionally registered outputs
+- Routing architecture:
+- 10% L = 1, fc_in = 0.15, Fc_out = 0.10
+- 10% L = 2, fc_in = 0.15, Fc_out = 0.10
+- 80% L = 4, fc_in = 0.15, Fc_out = 0.10
+- 100 routing tracks per channel
 
-  Authors: Xifan Tang
+Authors: Xifan Tang
 -->
 <architecture>
-  <!-- 
-       ODIN II specific config begins 
-       Describes the types of user-specified netlist blocks (in blif, this corresponds to 
-       ".model [type_of_block]") that this architecture supports.
+    <!-- 
+        ODIN II specific config begins 
+        Describes the types of user-specified netlist blocks (in blif, this corresponds to 
+        ".model [type_of_block]") that this architecture supports.
 
-       Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
-       already special structures in blif (.names, .input, .output, and .latch) 
-       that describe them.
-  -->
-  <models>
-    <!-- A virtual model for I/O to be used in the physical mode of io block -->
-    <!--model name="io">
-      <input_ports>
-        <port name="outpad"/>
-      </input_ports>
-      <output_ports>
-        <port name="inpad"/>
-      </output_ports>
-    </mode-->
-    <model name="intf_model">
-      <input_ports>
-        <port name="clk" is_clock="1"/>
-        <port name="SOC_IN" clock="clk"/>
-        <port name="FPGA_OUT" clock="clk"/>
-      </input_ports>
-      <output_ports>
-        <port name="FPGA_IN" clock="clk"/>
-        <port name="SOC_OUT" clock="clk"/>
-      </output_ports>
-    </model>
-    <model name="frac_lut4">
-      <input_ports>
-        <port name="in"/>
-      </input_ports>
-      <output_ports>
-        <port name="lut2_out"/>
-        <port name="lut4_out"/>
-      </output_ports>
-    </model>
-    <model name="carry_follower">
-      <input_ports>
-        <port name="a"/>
-        <port name="b"/>
-        <port name="cin"/>
-      </input_ports>
-      <output_ports>
-        <port name="cout"/>
-      </output_ports>
-    </model>
-    <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
-    <model name="scff">
-      <input_ports>
-        <port name="D" clock="clk"/>
-        <port name="DI" clock="clk"/>
-        <port name="reset" clock="clk"/>
-        <port name="clk" is_clock="1"/>
-      </input_ports>
-      <output_ports>
-        <port name="Q" clock="clk"/>
-      </output_ports>
-    </model>
-  </models>
-  <tiles>
-    <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
-         If you need to register the I/O, define clocks in the circuit models
-         These clocks can be handled in back-end
-     -->
-    <!-- Top-side has 1 I/O per tile -->
-    <tile name="io_top" capacity="16" area="0">
-      <equivalent_sites>
-        <site pb_type="interface"/>
-      </equivalent_sites>
-      <clock name="clk" num_pins="1"/>
-      <input name="SOC_IN" num_pins="1"/>
-      <input name="FPGA_OUT" num_pins="1"/>
-      <output name="FPGA_IN" num_pins="1"/>
-      <output name="SOC_OUT" num_pins="1"/>
-      <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
-      <pinlocations pattern="custom">
-        <loc side="bottom">io_top.FPGA_IN io_top.FPGA_OUT io_top.SOC_IN io_top.SOC_OUT io_top.clk</loc>
-      </pinlocations>
-    </tile>
-    <!-- Right-side has 1 I/O per tile -->
-    <tile name="io_right" capacity="16" area="0">
-      <equivalent_sites>
-        <site pb_type="interface"/>
-      </equivalent_sites>
-      <clock name="clk" num_pins="1"/>
-      <input name="SOC_IN" num_pins="1"/>
-      <input name="FPGA_OUT" num_pins="1"/>
-      <output name="FPGA_IN" num_pins="1"/>
-      <output name="SOC_OUT" num_pins="1"/>
-      <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
-      <pinlocations pattern="custom">
-        <loc side="left">io_right.FPGA_IN io_right.FPGA_OUT io_right.SOC_IN io_right.SOC_OUT io_right.clk</loc>
-      </pinlocations>
-    </tile>
-    <!-- Bottom-side has 9 I/O per tile -->
-    <tile name="io_bottom" capacity="16" area="0">
-      <equivalent_sites>
-        <site pb_type="interface"/>
-      </equivalent_sites>
-      <clock name="clk" num_pins="1"/>
-      <input name="SOC_IN" num_pins="1"/>
-      <input name="FPGA_OUT" num_pins="1"/>
-      <output name="FPGA_IN" num_pins="1"/>
-      <output name="SOC_OUT" num_pins="1"/>
-      <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
-      <pinlocations pattern="custom">
-        <loc side="top">io_bottom.FPGA_IN io_bottom.FPGA_OUT io_bottom.SOC_IN io_bottom.SOC_OUT io_bottom.clk</loc>
-      </pinlocations>
-    </tile>
-    <!-- Left-side has 1 I/O per tile -->
-    <tile name="io_left" capacity="16" area="0">
-      <equivalent_sites>
-        <site pb_type="interface"/>
-      </equivalent_sites>
-      <clock name="clk" num_pins="1"/>
-      <input name="SOC_IN" num_pins="1"/>
-      <input name="FPGA_OUT" num_pins="1"/>
-      <output name="FPGA_IN" num_pins="1"/>
-      <output name="SOC_OUT" num_pins="1"/>
-      <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
-      <pinlocations pattern="custom">
-        <loc side="right">io_left.FPGA_IN io_left.FPGA_OUT io_left.SOC_IN io_left.SOC_OUT io_left.clk</loc>
-      </pinlocations>
-    </tile>
-    <!-- CLB has most pins on the top and right sides -->
-    <tile name="clb" area="53894">
-      <equivalent_sites>
-        <site pb_type="clb"/>
-      </equivalent_sites>
-      <input name="I" num_pins="24" equivalent="full"/>
-      <input name="reg_in" num_pins="1"/>
-      <input name="sc_in" num_pins="1"/>
-      <input name="cin" num_pins="1"/>
-      <input name="reset" num_pins="1" is_non_clock_global="true"/>
-      <output name="O" num_pins="8" equivalent="none"/>
-      <output name="reg_out" num_pins="1"/>
-      <output name="sc_out" num_pins="1"/>
-      <output name="cout" num_pins="1"/>
-      <clock name="clk" num_pins="1"/>
-      <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
-        <fc_override port_name="reg_in" fc_type="frac" fc_val="0"/>
-        <fc_override port_name="reg_out" fc_type="frac" fc_val="0"/>
-        <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>
-        <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>
-        <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
-        <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
-        <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
-        <fc_override port_name="reset" fc_type="frac" fc_val="0"/>
-      </fc>
-      <!--pinlocations pattern="spread"/-->
-      <pinlocations pattern="custom">
-        <loc side="left">clb.clk clb.reset</loc>
-        <loc side="top">clb.reg_in clb.sc_in clb.cin clb.O[7:0] clb.I[11:0]</loc>
-        <loc side="right">clb.I[23:12]</loc>
-        <loc side="bottom">clb.reg_out clb.sc_out clb.cout</loc>
-      </pinlocations>
-    </tile>
-  </tiles>
-  <!-- ODIN II specific config ends -->
-  <!-- Physical descriptions begin -->
-  <layout tileable="true">
-    <auto_layout aspect_ratio="1.0">
-      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
-      <row type="io_top" starty="H-1" priority="100"/>
-      <row type="io_bottom" starty="0" priority="100"/>
-      <col type="io_left" startx="0" priority="100"/>
-      <col type="io_right" startx="W-1" priority="100"/>
-      <corners type="EMPTY" priority="101"/>
-      <!--Fill with 'clb'-->
-      <fill type="clb" priority="10"/>
-    </auto_layout>
-    <fixed_layout name="2x2" width="4" height="4">
-      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
-      <row type="io_top" starty="H-1" priority="100"/>
-      <row type="io_bottom" starty="0" priority="100"/>
-      <col type="io_left" startx="0" priority="100"/>
-      <col type="io_right" startx="W-1" priority="100"/>
-      <corners type="EMPTY" priority="101"/>
-      <!--Fill with 'clb'-->
-      <fill type="clb" priority="10"/>
-    </fixed_layout>
-    <fixed_layout name="12x12" width="14" height="14">
-      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
-      <row type="io_top" starty="H-1" priority="100"/>
-      <row type="io_bottom" starty="0" priority="100"/>
-      <col type="io_left" startx="0" priority="100"/>
-      <col type="io_right" startx="W-1" priority="100"/>
-      <corners type="EMPTY" priority="101"/>
-      <!--Fill with 'clb'-->
-      <fill type="clb" priority="10"/>
-    </fixed_layout>
-    <fixed_layout name="32x32" width="34" height="34">
-      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
-      <row type="io_top" starty="H-1" priority="100"/>
-      <row type="io_bottom" starty="0" priority="100"/>
-      <col type="io_left" startx="0" priority="100"/>
-      <col type="io_right" startx="W-1" priority="100"/>
-      <corners type="EMPTY" priority="101"/>
-      <!--Fill with 'clb'-->
-      <fill type="clb" priority="10"/>
-    </fixed_layout>
-  </layout>
-  <device>
-    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
-			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
-			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
-			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
-			     45 nm in general). I'm upping the Rmin_nmos from Ian's just over 6k to nearly 9k, and dropping 
-			     RminW_pmos from 18k to 16k to hit this 1.8x ratio, while keeping the delays of buffers approximately
-			     lined up with Stratix IV. 
-			     We are using Jeff G.'s capacitance data for 45 nm (in tech/ptm_45nm).
-			     Jeff's tables list C in for transistors with widths in multiples of the minimum feature size (45 nm).
-			     The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply drive strength sizes in this file
-	                     by 2.5x when looking up in Jeff's tables.
-			     The delay values are lined up with Stratix IV, which has an architecture similar to this
-			     proposed FPGA, and which is also 40 nm 
-			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
-			     4x minimum drive strength buffer. -->
-    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
-    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
-     	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
-	  -->
-    <area grid_logic_tile_area="0"/>
-    <chan_width_distr>
-      <x distr="uniform" peak="1.000000"/>
-      <y distr="uniform" peak="1.000000"/>
-    </chan_width_distr>
-    <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
-    <connection_block input_switch_name="ipin_cblock"/>
-  </device>
-  <switchlist>
-    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
-	       book area formula. This means the mux transistors are about 5x minimum drive strength.
-	       We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
-	       mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
-	       the n and p transistors in the first stage are equal-sized to lower the buffer trip point, since it's fed
-	       by a pass transistor mux. We can then reverse engineer the buffer second stage to hit the specified 
-	       buf_size (really buffer area) - 16.2x minimum drive nmos and 1.8*16.2 = 29.2x minimum drive.
-	       I then took the data from Jeff G.'s PTM modeling of 45 nm to get the Cin (gate of first stage) and Cout 
-	       (diff of second stage) listed below.  Jeff's models are in tech/ptm_45nm, and are in min feature multiples.
-	       The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
-	       2.5x when looking up in Jeff's tables.
-	       Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
-	       This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
-    <switch type="mux" name="L1_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
-    <switch type="mux" name="L2_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
-    <switch type="mux" name="L4_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
-    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
-    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
-  </switchlist>
-  <segmentlist>
-    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
-			     With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
-			     reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
-    <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
-    <segment name="L1" freq="0.20" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">
-      <mux name="L1_mux"/>
-      <sb type="pattern">1 1</sb>
-      <cb type="pattern">1</cb>
-    </segment>
-    <segment name="L2" freq="0.10" length="2" type="unidir" Rmetal="101" Cmetal="22.5e-15">
-      <mux name="L2_mux"/>
-      <sb type="pattern">1 1 1</sb>
-      <cb type="pattern">1 1</cb>
-    </segment>
-    <segment name="L4" freq="0.70" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
-      <mux name="L4_mux"/>
-      <sb type="pattern">1 1 1 1 1</sb>
-      <cb type="pattern">1 1 1 1</cb>
-    </segment>
-  </segmentlist>
-  <directlist>
-    <direct name="carry_chain" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
-    <direct name="shift_register" from_pin="clb.reg_out" to_pin="clb.reg_in" x_offset="0" y_offset="-1" z_offset="0"/>
-    <direct name="scan_chain" from_pin="clb.sc_out" to_pin="clb.sc_in" x_offset="0" y_offset="-1" z_offset="0"/>
-  </directlist>
-  <complexblocklist>
-    <!-- Define I/O pads begins -->
-    <pb_type name="interface">
-      <clock name="clk" num_pins="1"/>
-      <input name="SOC_IN" num_pins="1"/>
-      <input name="FPGA_OUT" num_pins="1"/>
-      <output name="FPGA_IN" num_pins="1"/>
-      <output name="SOC_OUT" num_pins="1"/>
-      <!-- Physical mode definition begin (physical implementation of the interface) -->
-      <mode name="physical" disabled_in_pack="true">
-          <pb_type name="intf_fabric" blif_model=".subckt intf_model" num_pb="1">
+        Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
+        already special structures in blif (.names, .input, .output, and .latch) 
+        that describe them.
+    -->
+    <models>
+        <!-- A virtual model for I/O to be used in the physical mode of io block -->
+        <model name="frac_lut4">
+            <input_ports>
+                <port name="in"/>
+            </input_ports>
+            <output_ports>
+                <port name="lut2_out"/>
+                <port name="lut4_out"/>
+            </output_ports>
+        </model>
+        <model name="carry_follower">
+            <input_ports>
+                <port name="a"/>
+                <port name="b"/>
+                <port name="cin"/>
+            </input_ports>
+            <output_ports>
+                <port name="cout"/>
+            </output_ports>
+        </model>
+        <!-- A virtual model for scan-chain flip-flop to be used in the physical mode of FF -->
+        <model name="scff">
+            <input_ports>
+                <port name="D" clock="clk"/>
+                <port name="DI" clock="clk"/>
+                <port name="reset" clock="clk"/>
+                <port name="clk" is_clock="1"/>
+            </input_ports>
+            <output_ports>
+                <port name="Q" clock="clk"/>
+            </output_ports>
+        </model>
+    </models>
+    <tiles>
+        <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
+            If you need to register the I/O, define clocks in the circuit models
+            These clocks can be handled in back-end
+        -->
+        <!-- Top-side has 1 I/O per tile -->
+        <tile name="io_top" capacity="16" area="0">
+            <equivalent_sites>
+                <site pb_type="io"/>
+            </equivalent_sites>
             <clock name="clk" num_pins="1"/>
             <input name="SOC_IN" num_pins="1"/>
             <input name="FPGA_OUT" num_pins="1"/>
             <output name="FPGA_IN" num_pins="1"/>
             <output name="SOC_OUT" num_pins="1"/>
-            <T_setup value="66e-12" port="intf_fabric.SOC_IN" clock="clk"/>
-            <T_setup value="66e-12" port="intf_fabric.FPGA_OUT" clock="clk"/>
-            <T_clock_to_Q max="124e-12" port="intf_fabric.FPGA_IN" clock="clk"/>
-            <T_clock_to_Q max="124e-12" port="intf_fabric.SOC_OUT" clock="clk"/>
-          </pb_type>
-          <interconnect>
-            <direct name="direct1" input="interface.clk" output="intf_fabric.clk"/>
-            <direct name="direct2" input="interface.SOC_IN" output="intf_fabric.SOC_IN"/>
-            <direct name="direct3" input="interface.FPGA_OUT" output="intf_fabric.FPGA_OUT"/>
-            <direct name="direct4" input="intf_fabric.FPGA_IN" output="interface.FPGA_IN"/>
-            <direct name="direct5" input="intf_fabric.SOC_OUT" output="interface.SOC_OUT"/>
-          </interconnect>
-      </mode>
-      <!-- Physical mode definition end (physical implementation of the interface) -->
-      <mode name="io_input">
-        <pb_type name="io_input" num_pb="1">
-          <clock name="clk" num_pins="1"/>
-          <input name="SOC_IN" num_pins="1"/>
-          <output name="FPGA_IN" num_pins="1"/>
-          <pb_type name="inpad" blif_model=".input" num_pb="1">
-            <output name="inpad" num_pins="1"/>
-          </pb_type>
-          <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
-            <input name="D" num_pins="1" port_class="D"/>
-            <output name="Q" num_pins="1" port_class="Q"/>
-            <clock name="clk" num_pins="1" port_class="clock"/>
-            <T_setup value="66e-12" port="ff.D" clock="clk"/>
-            <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
-          </pb_type>
-          <interconnect>
-            <direct name="io_input-FPGA_IN" input="inpad.inpad" output="io_input.FPGA_IN">
-              <pack_pattern name="pack-IPAD_TO_IBUF" in_port="inpad.inpad" out_port="io_input.FPGA_IN"/>
-            </direct>
-            <direct name="ff-clk" input="io_input.clk" output="ff.clk"/>
-            <direct name="ff-Q" input="ff.Q" output="io_input.FPGA_IN" />
-            <direct name="ff-D" input="inpad.inpad" output="ff.D">
-              <pack_pattern name="pack-IPAD_TO_IREG" in_port="inpad.inpad" out_port="ff.D"/>
-            </direct>
-          </interconnect>
-        </pb_type>
-        <interconnect>
-          <direct name="interface-FPGA_IN" input="io_input.FPGA_IN" output="interface.FPGA_IN"/>
-          <direct name="io_input-SOC_IN" input="interface.SOC_IN" output="io_input.SOC_IN"/>
-          <direct name="io_input-clk" input="interface.clk" output="io_input.clk"/>
-        </interconnect>
-      </mode>
-      <mode name="io_output">
-        <pb_type name="io_output" num_pb="1">
-          <clock name="clk" num_pins="1"/>
-          <input name="FPGA_OUT" num_pins="1"/>
-          <output name="SOC_OUT" num_pins="1"/>
-          <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
-            <input name="D" num_pins="1" port_class="D"/>
-            <output name="Q" num_pins="1" port_class="Q"/>
-            <clock name="clk" num_pins="1" port_class="clock"/>
-            <T_setup value="66e-12" port="ff.D" clock="clk"/>
-            <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
-          </pb_type>
-          <pb_type name="outpad" blif_model=".output" num_pb="1">
-            <input name="outpad" num_pins="1"/>
-          </pb_type>
-          <interconnect>
-            <direct name="io_output-FPGA_OUT" input="io_output.FPGA_OUT" output="outpad.outpad">
-              <pack_pattern name="pack-OBUF_TO_OPAD" in_port="io_output.FPGA_OUT" out_port="outpad.outpad"/>
-            </direct>
-            <direct name="ff-clk" input="io_output.clk" output="ff.clk"/>
-            <direct name="ff-D" input="io_output.FPGA_OUT" output="ff.D"/>
-            <direct name="outpad-outpad" input="ff.Q" output="outpad.outpad">
-              <pack_pattern name="pack-OBUF_TO_OREG" in_port="ff.Q" out_port="outpad.outpad"/>
-            </direct>
-          </interconnect>
-        </pb_type>
-        <interconnect>
-          <direct input="io_output.SOC_OUT" name="interface-SOC_OUT" output="interface.SOC_OUT"/>
-          <direct input="interface.clk" name="io_output-clk" output="io_output.clk"/>
-          <direct input="interface.FPGA_OUT" name="io_output-FPGA_OUT" output="io_output.FPGA_OUT"/>
-        </interconnect>
-      </mode>
-    </pb_type>
-    <!-- Define I/O pads ends -->
-    <!-- Define general purpose logic block (CLB) begin -->
-    <!-- -Due to the absence of local routing, 
-         the 4 inputs of fracturable LUT4 are no longer equivalent, 
-         because the 4th input can not be switched when the dual-LUT3 modes are used.
-         So pin equivalence should be applied to the first 3 inputs only
-	  -->
-    <pb_type name="clb">
-      <input name="I" num_pins="24" equivalent="full"/>
-      <input name="reg_in" num_pins="1"/>
-      <input name="sc_in" num_pins="1"/>
-      <input name="cin" num_pins="1"/>
-      <input name="reset" num_pins="1" is_non_clock_global="true"/>
-      <output name="O" num_pins="8" equivalent="none"/>
-      <output name="reg_out" num_pins="1"/>
-      <output name="sc_out" num_pins="1"/>
-      <output name="cout" num_pins="1"/>
-      <clock name="clk" num_pins="1"/>
-      <!-- Describe fracturable logic element.  
-             Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
-             The outputs of the fracturable logic element can be optionally registered
-        -->
-      <pb_type name="fle" num_pb="8">
-        <input name="in" num_pins="4"/>
-        <input name="reg_in" num_pins="1"/>
-        <input name="sc_in" num_pins="1"/>
-        <input name="cin" num_pins="1"/>
-        <input name="reset" num_pins="1"/>
-        <output name="out" num_pins="1"/>
-        <output name="reg_out" num_pins="1"/>
-        <output name="sc_out" num_pins="1"/>
-        <output name="cout" num_pins="1"/>
-        <clock name="clk" num_pins="1"/>
-        <!-- Physical mode definition begin (physical implementation of the fle) -->
-        <mode name="physical" disabled_in_pack="true">
-          <pb_type name="fabric" num_pb="1">
-            <input name="in" num_pins="4"/>
+            <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+            <pinlocations pattern="custom">
+                <loc side="bottom">io_top.FPGA_IN io_top.FPGA_OUT io_top.SOC_IN io_top.SOC_OUT io_top.clk</loc>
+            </pinlocations>
+        </tile>
+        <!-- Right-side has 1 I/O per tile -->
+        <tile name="io_right" capacity="16" area="0">
+            <equivalent_sites>
+                <site pb_type="io"/>
+            </equivalent_sites>
+            <clock name="clk" num_pins="1"/>
+            <input name="SOC_IN" num_pins="1"/>
+            <input name="FPGA_OUT" num_pins="1"/>
+            <output name="FPGA_IN" num_pins="1"/>
+            <output name="SOC_OUT" num_pins="1"/>
+            <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+            <pinlocations pattern="custom">
+                <loc side="left">io_right.FPGA_IN io_right.FPGA_OUT io_right.SOC_IN io_right.SOC_OUT io_right.clk</loc>
+            </pinlocations>
+        </tile>
+        <!-- Bottom-side has 9 I/O per tile -->
+        <tile name="io_bottom" capacity="16" area="0">
+            <equivalent_sites>
+                <site pb_type="io"/>
+            </equivalent_sites>
+            <clock name="clk" num_pins="1"/>
+            <input name="SOC_IN" num_pins="1"/>
+            <input name="FPGA_OUT" num_pins="1"/>
+            <output name="FPGA_IN" num_pins="1"/>
+            <output name="SOC_OUT" num_pins="1"/>
+            <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+            <pinlocations pattern="custom">
+                <loc side="top">io_bottom.FPGA_IN io_bottom.FPGA_OUT io_bottom.SOC_IN io_bottom.SOC_OUT io_bottom.clk</loc>
+            </pinlocations>
+        </tile>
+        <!-- Left-side has 1 I/O per tile -->
+        <tile name="io_left" capacity="16" area="0">
+            <equivalent_sites>
+                <site pb_type="io"/>
+            </equivalent_sites>
+            <clock name="clk" num_pins="1"/>
+            <input name="SOC_IN" num_pins="1"/>
+            <input name="FPGA_OUT" num_pins="1"/>
+            <output name="FPGA_IN" num_pins="1"/>
+            <output name="SOC_OUT" num_pins="1"/>
+            <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+            <pinlocations pattern="custom">
+                <loc side="right">io_left.FPGA_IN io_left.FPGA_OUT io_left.SOC_IN io_left.SOC_OUT io_left.clk</loc>
+            </pinlocations>
+        </tile>
+        <!-- CLB has most pins on the top and right sides -->
+        <tile name="clb" area="53894">
+            <equivalent_sites>
+                <site pb_type="clb"/>
+            </equivalent_sites>
+            <input name="I" num_pins="24" equivalent="full"/>
             <input name="reg_in" num_pins="1"/>
             <input name="sc_in" num_pins="1"/>
             <input name="cin" num_pins="1"/>
-            <input name="reset" num_pins="1"/>
-            <output name="out" num_pins="1"/>
+            <input name="reset" num_pins="1" is_non_clock_global="true"/>
+            <output name="O" num_pins="8" equivalent="none"/>
             <output name="reg_out" num_pins="1"/>
             <output name="sc_out" num_pins="1"/>
             <output name="cout" num_pins="1"/>
             <clock name="clk" num_pins="1"/>
-            <pb_type name="frac_logic" num_pb="1">
-              <input name="in" num_pins="4"/>
-              <input name="cin" num_pins="1"/>
-              <output name="out" num_pins="1"/>
-              <output name="cout" num_pins="1"/>
-              <!-- Define LUT -->
-              <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
-                <input name="in" num_pins="4"/>
-                <output name="lut2_out" num_pins="2"/>
-                <output name="lut4_out" num_pins="1"/>
-              </pb_type>
-              <pb_type name="carry_follower" blif_model=".subckt carry_follower" num_pb="1">
-                <input name="a" num_pins="1"/>
-                <input name="b" num_pins="1"/>
-                <input name="cin" num_pins="1"/>
-                <output name="cout" num_pins="1"/>
-              </pb_type>
-              <interconnect>
-                <direct name="direct1" input="frac_logic.in[0:1]" output="frac_lut4.in[0:1]"/>
-                <direct name="direct2" input="frac_logic.in[3:3]" output="frac_lut4.in[3:3]"/>
-                <direct name="direct3" input="frac_logic.cin" output="carry_follower.b"/>
-                <direct name="direct4" input="frac_lut4.lut2_out[1:1]" output="carry_follower.a"/>
-                <direct name="direct5" input="frac_lut4.lut2_out[0:0]" output="carry_follower.cin"/>
-                <direct name="direct6" input="carry_follower.cout" output="frac_logic.cout"/>
-                <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
-                <direct name="direct7" input="frac_lut4.lut4_out" output="frac_logic.out"/>
-                <mux name="mux2" input="frac_logic.cin frac_logic.in[2:2]" output="frac_lut4.in[2:2]"/>
-              </interconnect>
-            </pb_type>
-            <!-- Define flip-flop with scan-chain capability, DI is the scan-chain data input -->
-            <pb_type name="ff" blif_model=".subckt scff" num_pb="1">
-              <input name="D" num_pins="1"/>
-              <input name="DI" num_pins="1"/>
-              <input name="reset" num_pins="1"/>
-              <output name="Q" num_pins="1"/>
-              <clock name="clk" num_pins="1"/>
-              <T_setup value="66e-12" port="ff.D" clock="clk"/>
-              <T_setup value="66e-12" port="ff.DI" clock="clk"/>
-              <T_setup value="66e-12" port="ff.reset" clock="clk"/>
-              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
-            </pb_type>         
-            <interconnect>
-              <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
-              <direct name="direct2" input="fabric.sc_in" output="ff.DI"/>
-              <direct name="direct4" input="ff.Q" output="fabric.sc_out"/>
-              <direct name="direct5" input="ff.Q" output="fabric.reg_out"/>
-              <direct name="direct6" input="frac_logic.cout" output="fabric.cout"/>
-              <complete name="complete1" input="fabric.clk" output="ff.clk"/>
-              <complete name="complete2" input="fabric.reset" output="ff.reset"/>
-              <mux name="mux1" input="frac_logic.out fabric.reg_in" output="ff.D">
-                <delay_constant max="25e-12" in_port="frac_logic.out" out_port="ff.D"/>
-                <delay_constant max="45e-12" in_port="fabric.reg_in" out_port="ff.D"/>
-              </mux>
-              <mux name="mux2" input="ff.Q frac_logic.out" output="fabric.out">
-                <!-- LUT to output is faster than FF to output on a Stratix IV -->
-                <delay_constant max="25e-12" in_port="frac_logic.out" out_port="fabric.out"/>
-                <delay_constant max="45e-12" in_port="ff.Q" out_port="fabric.out"/>
-              </mux>
-            </interconnect>
-          </pb_type>
-          <interconnect>
-            <direct name="direct1" input="fle.in" output="fabric.in"/>
-            <direct name="direct2" input="fle.reg_in" output="fabric.reg_in"/>
-            <direct name="direct3" input="fle.sc_in" output="fabric.sc_in"/>
-            <direct name="direct4" input="fle.cin" output="fabric.cin"/>
-            <direct name="direct5" input="fabric.out" output="fle.out"/>
-            <direct name="direct6" input="fabric.reg_out" output="fle.reg_out"/>
-            <direct name="direct7" input="fabric.sc_out" output="fle.sc_out"/>
-            <direct name="direct8" input="fabric.cout" output="fle.cout"/>
-            <direct name="direct9" input="fle.clk" output="fabric.clk"/>
-            <direct name="direct10" input="fle.reset" output="fabric.reset"/>
-          </interconnect>
-        </mode>
-        <!-- Physical mode definition end (physical implementation of the fle) -->
-        <mode name="n1_lut4">
-          <!-- Define 4-LUT mode -->
-          <pb_type name="ble4" num_pb="1">
-            <input name="in" num_pins="4"/>
-            <output name="out" num_pins="1"/>
+            <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+                <fc_override port_name="reg_in" fc_type="frac" fc_val="0"/>
+                <fc_override port_name="reg_out" fc_type="frac" fc_val="0"/>
+                <fc_override port_name="sc_in" fc_type="frac" fc_val="0"/>
+                <fc_override port_name="sc_out" fc_type="frac" fc_val="0"/>
+                <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+                <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+                <fc_override port_name="clk" fc_type="frac" fc_val="0"/>
+                <fc_override port_name="reset" fc_type="frac" fc_val="0"/>
+            </fc>
+            <!--pinlocations pattern="spread"/-->
+            <pinlocations pattern="custom">
+                <loc side="left">clb.clk clb.reset</loc>
+                <loc side="top">clb.reg_in clb.sc_in clb.cin clb.O[7:0] clb.I[11:0]</loc>
+                <loc side="right">clb.I[23:12]</loc>
+                <loc side="bottom">clb.reg_out clb.sc_out clb.cout</loc>
+            </pinlocations>
+        </tile>
+    </tiles>
+    <!-- ODIN II specific config ends -->
+    <!-- Physical descriptions begin -->
+    <layout tileable="true">
+        <auto_layout aspect_ratio="1.0">
+            <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+            <row type="io_top" starty="H-1" priority="100"/>
+            <row type="io_bottom" starty="0" priority="100"/>
+            <col type="io_left" startx="0" priority="100"/>
+            <col type="io_right" startx="W-1" priority="100"/>
+            <corners type="EMPTY" priority="101"/>
+                <!--Fill with 'clb'-->
+            <fill type="clb" priority="10"/>
+        </auto_layout>
+        <fixed_layout name="2x2" width="4" height="4">
+            <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+            <row type="io_top" starty="H-1" priority="100"/>
+            <row type="io_bottom" starty="0" priority="100"/>
+            <col type="io_left" startx="0" priority="100"/>
+            <col type="io_right" startx="W-1" priority="100"/>
+            <corners type="EMPTY" priority="101"/>
+                <!--Fill with 'clb'-->
+            <fill type="clb" priority="10"/>
+        </fixed_layout>
+        <fixed_layout name="12x12" width="14" height="14">
+            <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+            <row type="io_top" starty="H-1" priority="100"/>
+            <row type="io_bottom" starty="0" priority="100"/>
+            <col type="io_left" startx="0" priority="100"/>
+            <col type="io_right" startx="W-1" priority="100"/>
+            <corners type="EMPTY" priority="101"/>
+                <!--Fill with 'clb'-->
+            <fill type="clb" priority="10"/>
+        </fixed_layout>
+        <fixed_layout name="32x32" width="34" height="34">
+            <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+            <row type="io_top" starty="H-1" priority="100"/>
+            <row type="io_bottom" starty="0" priority="100"/>
+            <col type="io_left" startx="0" priority="100"/>
+            <col type="io_right" startx="W-1" priority="100"/>
+            <corners type="EMPTY" priority="101"/>
+                <!--Fill with 'clb'-->
+            <fill type="clb" priority="10"/>
+        </fixed_layout>
+    </layout>
+    <device>
+        <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+            models. We are modifying the delay values however, to include metal C and R, which allows more architecture
+            experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
+            (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
+            45 nm in general). I'm upping the Rmin_nmos from Ian's just over 6k to nearly 9k, and dropping 
+            RminW_pmos from 18k to 16k to hit this 1.8x ratio, while keeping the delays of buffers approximately
+            lined up with Stratix IV. 
+            We are using Jeff G.'s capacitance data for 45 nm (in tech/ptm_45nm).
+            Jeff's tables list C in for transistors with widths in multiples of the minimum feature size (45 nm).
+            The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply drive strength sizes in this file
+            by 2.5x when looking up in Jeff's tables.
+            The delay values are lined up with Stratix IV, which has an architecture similar to this
+            proposed FPGA, and which is also 40 nm 
+            C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
+        4x minimum drive strength buffer. -->
+        <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+            <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+                area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
+            -->
+        <area grid_logic_tile_area="0"/>
+        <chan_width_distr>
+            <x distr="uniform" peak="1.000000"/>
+            <y distr="uniform" peak="1.000000"/>
+        </chan_width_distr>
+        <switch_block type="wilton" fs="3" sub_type="subset" sub_fs="3"/>
+        <connection_block input_switch_name="ipin_cblock"/>
+    </device>
+    <switchlist>
+        <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+            book area formula. This means the mux transistors are about 5x minimum drive strength.
+            We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
+            mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
+            the n and p transistors in the first stage are equal-sized to lower the buffer trip point, since it's fed
+            by a pass transistor mux. We can then reverse engineer the buffer second stage to hit the specified 
+            buf_size (really buffer area) - 16.2x minimum drive nmos and 1.8*16.2 = 29.2x minimum drive.
+            I then took the data from Jeff G.'s PTM modeling of 45 nm to get the Cin (gate of first stage) and Cout 
+            (diff of second stage) listed below.  Jeff's models are in tech/ptm_45nm, and are in min feature multiples.
+            The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
+            2.5x when looking up in Jeff's tables.
+            Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
+        This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+        <switch type="mux" name="L1_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+        <switch type="mux" name="L2_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+        <switch type="mux" name="L4_mux" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+            <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+        <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+    </switchlist>
+    <segmentlist>
+        <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+            With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
+        reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+        <!-- GIVE a specific name for the segment! OpenFPGA appreciate that! -->
+        <segment name="L1" freq="0.20" length="1" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+            <mux name="L1_mux"/>
+            <sb type="pattern">1 1</sb>
+            <cb type="pattern">1</cb>
+        </segment>
+        <segment name="L2" freq="0.10" length="2" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+            <mux name="L2_mux"/>
+            <sb type="pattern">1 1 1</sb>
+            <cb type="pattern">1 1</cb>
+        </segment>
+        <segment name="L4" freq="0.70" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+            <mux name="L4_mux"/>
+            <sb type="pattern">1 1 1 1 1</sb>
+            <cb type="pattern">1 1 1 1</cb>
+        </segment>
+    </segmentlist>
+    <directlist>
+        <direct name="carry_chain" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+        <direct name="shift_register" from_pin="clb.reg_out" to_pin="clb.reg_in" x_offset="0" y_offset="-1" z_offset="0"/>
+        <direct name="scan_chain" from_pin="clb.sc_out" to_pin="clb.sc_in" x_offset="0" y_offset="-1" z_offset="0"/>
+    </directlist>
+    <complexblocklist>
+        <!-- Define I/O pads begins -->
+        <pb_type name="io">
             <clock name="clk" num_pins="1"/>
-            <!-- Define LUT -->
-            <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
-              <input name="in" num_pins="4" port_class="lut_in"/>
-              <output name="out" num_pins="1" port_class="lut_out"/>
-              <!-- LUT timing using delay matrix -->
-              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
-                       we instead take the average of these numbers to get more stable results
-                  82e-12
-                  173e-12
-                  261e-12
-                  263e-12
-                  398e-12
-                  397e-12
-                  -->
-              <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
-                261e-12
-                261e-12
-                261e-12
-                261e-12
-              </delay_matrix>
-            </pb_type>
-            <!-- Define flip-flop -->
-            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
-              <input name="D" num_pins="1" port_class="D"/>
-              <output name="Q" num_pins="1" port_class="Q"/>
-              <clock name="clk" num_pins="1" port_class="clock"/>
-              <T_setup value="66e-12" port="ff.D" clock="clk"/>
-              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
-            </pb_type>
-            <interconnect>
-              <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
-              <direct name="direct2" input="lut4.out" output="ff.D">
-                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
-                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
-              </direct>
-              <direct name="direct3" input="ble4.clk" output="ff.clk"/>
-              <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
-                <!-- LUT to output is faster than FF to output on a Stratix IV -->
-                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
-                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
-              </mux>
-            </interconnect>
-          </pb_type>
-          <interconnect>
-            <direct name="direct1" input="fle.in" output="ble4.in"/>
-            <direct name="direct2" input="ble4.out" output="fle.out"/>
-            <direct name="direct3" input="fle.clk" output="ble4.clk"/>
-          </interconnect>
-        </mode>
-        <!-- 4-LUT mode definition end -->
-        <!-- Define shift register begin -->
-        <mode name="shift_register" disable_packing="true">
-          <pb_type name="shift_reg" num_pb="1">
+            <input name="SOC_IN" num_pins="1"/>
+            <input name="FPGA_OUT" num_pins="1"/>
+            <output name="FPGA_IN" num_pins="1"/>
+            <output name="SOC_OUT" num_pins="1"/>
+                <!-- Physical mode definition begin (physical implementation of the io) -->
+            <mode name="physical" disabled_in_pack="true">
+                <pb_type name="intf_fabric" num_pb="1">
+                    <clock name="clk" num_pins="1"/>
+                    <input name="SOC_IN" num_pins="1"/>
+                    <input name="FPGA_OUT" num_pins="1"/>
+                    <output name="FPGA_IN" num_pins="1"/>
+                    <output name="SOC_OUT" num_pins="1"/>
+                    <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                        <input name="D" num_pins="1" port_class="D"/>
+                        <output name="Q" num_pins="1" port_class="Q"/>
+                        <clock name="clk" num_pins="1" port_class="clock"/>
+                        <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                        <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+                    </pb_type>
+                    <interconnect>
+                        <direct name="ff-clk" input="intf_fabric.clk" output="ff.clk"/>
+                        <mux name="mux1" input="intf_fabric.SOC_IN ff.Q" output="intf_fabric.FPGA_IN"/>
+                        <mux name="mux2" input="intf_fabric.FPGA_OUT ff.Q" output="intf_fabric.SOC_OUT"/>
+                        <mux name="mux3" input="intf_fabric.SOC_IN intf_fabric.FPGA_OUT" output="ff.D"/>
+                    </interconnect>
+                </pb_type>
+                <interconnect>
+                    <direct name="direct1" input="io.clk" output="intf_fabric.clk"/>
+                    <direct name="direct2" input="io.SOC_IN" output="intf_fabric.SOC_IN"/>
+                    <direct name="direct3" input="io.FPGA_OUT" output="intf_fabric.FPGA_OUT"/>
+                    <direct name="direct4" input="intf_fabric.FPGA_IN" output="io.FPGA_IN"/>
+                    <direct name="direct5" input="intf_fabric.SOC_OUT" output="io.SOC_OUT"/>
+                </interconnect>
+            </mode>
+            <!-- Physical mode definition end (physical implementation of the io) -->
+            <mode name="io_input">
+                <pb_type name="io_input" num_pb="1">
+                    <clock name="clk" num_pins="1"/>
+                    <input name="SOC_IN" num_pins="1"/>
+                    <output name="FPGA_IN" num_pins="1"/>
+                    <pb_type name="inpad" blif_model=".input" num_pb="1">
+                        <output name="inpad" num_pins="1"/>
+                    </pb_type>
+                    <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                        <input name="D" num_pins="1" port_class="D"/>
+                        <output name="Q" num_pins="1" port_class="Q"/>
+                        <clock name="clk" num_pins="1" port_class="clock"/>
+                        <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                        <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+                    </pb_type>
+                    <interconnect>
+                        <!--direct name="inpad.inpad" input="io_input.SOC_IN" output="inpad.inpad"/-->
+                        <direct name="ff-clk" input="io_input.clk" output="ff.clk"/>
+                        <direct name="ff-D" input="inpad.inpad" output="ff.D">
+                            <pack_pattern name="pack-IREG" in_port="inpad.inpad" out_port="ff.D"/>
+                        </direct>
+                        <mux name="mux1" input="inpad.inpad ff.Q" output="io_input.FPGA_IN"/>
+                    </interconnect>
+                </pb_type>
+                <interconnect>
+                    <direct name="io-FPGA_IN" input="io_input.FPGA_IN" output="io.FPGA_IN"/>
+                    <direct name="io_input-SOC_IN" input="io.SOC_IN" output="io_input.SOC_IN"/>
+                    <direct name="io_input-clk" input="io.clk" output="io_input.clk"/>
+                </interconnect>
+            </mode>
+            <mode name="io_output">
+                <pb_type name="io_output" num_pb="1">
+                    <clock name="clk" num_pins="1"/>
+                    <input name="FPGA_OUT" num_pins="1"/>
+                    <output name="SOC_OUT" num_pins="1"/>
+                    <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                        <input name="D" num_pins="1" port_class="D"/>
+                        <output name="Q" num_pins="1" port_class="Q"/>
+                        <clock name="clk" num_pins="1" port_class="clock"/>
+                        <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                        <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+                    </pb_type>
+                    <pb_type name="outpad" blif_model=".output" num_pb="1">
+                        <input name="outpad" num_pins="1"/>
+                    </pb_type>
+                    <interconnect>
+                        <direct name="ff-clk" input="io_output.clk" output="ff.clk"/>
+                        <direct name="ff-D" input="io_output.FPGA_OUT" output="ff.D"/>
+                        <mux name="mux2" input="ff.Q io_output.FPGA_OUT" output="outpad.outpad">
+                            <pack_pattern name="pack-OREG" in_port="ff.Q" out_port="outpad.outpad"/>
+                        </mux>
+                    </interconnect>
+                </pb_type>
+                <interconnect>
+                    <direct input="io_output.SOC_OUT" name="io-SOC_OUT" output="io.SOC_OUT"/>
+                    <direct input="io.clk" name="io_output-clk" output="io_output.clk"/>
+                    <direct input="io.FPGA_OUT" name="io_output-FPGA_OUT" output="io_output.FPGA_OUT"/>
+                </interconnect>
+            </mode>
+        </pb_type>
+        <!-- Define I/O pads ends -->
+        <!-- Define general purpose logic block (CLB) begin -->
+        <!-- -Due to the absence of local routing, 
+            the 4 inputs of fracturable LUT4 are no longer equivalent, 
+            because the 4th input can not be switched when the dual-LUT3 modes are used.
+            So pin equivalence should be applied to the first 3 inputs only
+        -->
+        <pb_type name="clb">
+            <input name="I" num_pins="24" equivalent="full"/>
             <input name="reg_in" num_pins="1"/>
-            <output name="ff_out" num_pins="1"/>
+            <input name="sc_in" num_pins="1"/>
+            <input name="cin" num_pins="1"/>
+            <input name="reset" num_pins="1" is_non_clock_global="true"/>
+            <output name="O" num_pins="8" equivalent="none"/>
             <output name="reg_out" num_pins="1"/>
+            <output name="sc_out" num_pins="1"/>
+            <output name="cout" num_pins="1"/>
             <clock name="clk" num_pins="1"/>
-            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
-              <input name="D" num_pins="1" port_class="D"/>
-              <output name="Q" num_pins="1" port_class="Q"/>
-              <clock name="clk" num_pins="1" port_class="clock"/>
-              <T_setup value="66e-12" port="ff.D" clock="clk"/>
-              <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+                <!-- Describe fracturable logic element.  
+                    Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
+                    The outputs of the fracturable logic element can be optionally registered
+                -->
+            <pb_type name="fle" num_pb="8">
+                <input name="in" num_pins="4"/>
+                <input name="reg_in" num_pins="1"/>
+                <input name="sc_in" num_pins="1"/>
+                <input name="cin" num_pins="1"/>
+                <input name="reset" num_pins="1"/>
+                <output name="out" num_pins="1"/>
+                <output name="reg_out" num_pins="1"/>
+                <output name="sc_out" num_pins="1"/>
+                <output name="cout" num_pins="1"/>
+                <clock name="clk" num_pins="1"/>
+                    <!-- Physical mode definition begin (physical implementation of the fle) -->
+                <mode name="physical" disabled_in_pack="true">
+                    <pb_type name="fabric" num_pb="1">
+                        <input name="in" num_pins="4"/>
+                        <input name="reg_in" num_pins="1"/>
+                        <input name="sc_in" num_pins="1"/>
+                        <input name="cin" num_pins="1"/>
+                        <input name="reset" num_pins="1"/>
+                        <output name="out" num_pins="1"/>
+                        <output name="reg_out" num_pins="1"/>
+                        <output name="sc_out" num_pins="1"/>
+                        <output name="cout" num_pins="1"/>
+                        <clock name="clk" num_pins="1"/>
+                        <pb_type name="frac_logic" num_pb="1">
+                            <input name="in" num_pins="4"/>
+                            <input name="cin" num_pins="1"/>
+                            <output name="out" num_pins="1"/>
+                            <output name="cout" num_pins="1"/>
+                                <!-- Define LUT -->
+                            <pb_type name="frac_lut4" blif_model=".subckt frac_lut4" num_pb="1">
+                                <input name="in" num_pins="4"/>
+                                <output name="lut2_out" num_pins="2"/>
+                                <output name="lut4_out" num_pins="1"/>
+                            </pb_type>
+                            <pb_type name="carry_follower" blif_model=".subckt carry_follower" num_pb="1">
+                                <input name="a" num_pins="1"/>
+                                <input name="b" num_pins="1"/>
+                                <input name="cin" num_pins="1"/>
+                                <output name="cout" num_pins="1"/>
+                            </pb_type>
+                            <interconnect>
+                                <direct name="direct1" input="frac_logic.in[0:1]" output="frac_lut4.in[0:1]"/>
+                                <direct name="direct2" input="frac_logic.in[3:3]" output="frac_lut4.in[3:3]"/>
+                                <direct name="direct3" input="frac_logic.cin" output="carry_follower.b"/>
+                                <direct name="direct4" input="frac_lut4.lut2_out[1:1]" output="carry_follower.a"/>
+                                <direct name="direct5" input="frac_lut4.lut2_out[0:0]" output="carry_follower.cin"/>
+                                <direct name="direct6" input="carry_follower.cout" output="frac_logic.cout"/>
+                                    <!-- Xifan Tang: I use out[0] because the output of lut6 in lut6 mode is wired to the out[0] -->
+                                <direct name="direct7" input="frac_lut4.lut4_out" output="frac_logic.out"/>
+                                <mux name="mux2" input="frac_logic.cin frac_logic.in[2:2]" output="frac_lut4.in[2:2]"/>
+                            </interconnect>
+                        </pb_type>
+                        <!-- Define flip-flop with scan-chain capability, DI is the scan-chain data input -->
+                        <pb_type name="ff" blif_model=".subckt scff" num_pb="1">
+                            <input name="D" num_pins="1"/>
+                            <input name="DI" num_pins="1"/>
+                            <input name="reset" num_pins="1"/>
+                            <output name="Q" num_pins="1"/>
+                            <clock name="clk" num_pins="1"/>
+                            <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                            <T_setup value="66e-12" port="ff.DI" clock="clk"/>
+                            <T_setup value="66e-12" port="ff.reset" clock="clk"/>
+                            <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+                        </pb_type>         
+                        <interconnect>
+                            <direct name="direct1" input="fabric.in" output="frac_logic.in"/>
+                            <direct name="direct2" input="fabric.sc_in" output="ff.DI"/>
+                            <direct name="direct4" input="ff.Q" output="fabric.sc_out"/>
+                            <direct name="direct5" input="ff.Q" output="fabric.reg_out"/>
+                            <direct name="direct6" input="frac_logic.cout" output="fabric.cout"/>
+                            <complete name="complete1" input="fabric.clk" output="ff.clk"/>
+                            <complete name="complete2" input="fabric.reset" output="ff.reset"/>
+                            <mux name="mux1" input="frac_logic.out fabric.reg_in" output="ff.D">
+                                <delay_constant max="25e-12" in_port="frac_logic.out" out_port="ff.D"/>
+                                <delay_constant max="45e-12" in_port="fabric.reg_in" out_port="ff.D"/>
+                            </mux>
+                            <mux name="mux2" input="ff.Q frac_logic.out" output="fabric.out">
+                                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                                <delay_constant max="25e-12" in_port="frac_logic.out" out_port="fabric.out"/>
+                                <delay_constant max="45e-12" in_port="ff.Q" out_port="fabric.out"/>
+                            </mux>
+                        </interconnect>
+                    </pb_type>
+                    <interconnect>
+                        <direct name="direct1" input="fle.in" output="fabric.in"/>
+                        <direct name="direct2" input="fle.reg_in" output="fabric.reg_in"/>
+                        <direct name="direct3" input="fle.sc_in" output="fabric.sc_in"/>
+                        <direct name="direct4" input="fle.cin" output="fabric.cin"/>
+                        <direct name="direct5" input="fabric.out" output="fle.out"/>
+                        <direct name="direct6" input="fabric.reg_out" output="fle.reg_out"/>
+                        <direct name="direct7" input="fabric.sc_out" output="fle.sc_out"/>
+                        <direct name="direct8" input="fabric.cout" output="fle.cout"/>
+                        <direct name="direct9" input="fle.clk" output="fabric.clk"/>
+                        <direct name="direct10" input="fle.reset" output="fabric.reset"/>
+                    </interconnect>
+                </mode>
+                <!-- Physical mode definition end (physical implementation of the fle) -->
+                <mode name="n1_lut4">
+                    <!-- Define 4-LUT mode -->
+                    <pb_type name="ble4" num_pb="1">
+                        <input name="in" num_pins="4"/>
+                        <output name="out" num_pins="1"/>
+                        <clock name="clk" num_pins="1"/>
+                            <!-- Define LUT -->
+                        <pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
+                            <input name="in" num_pins="4" port_class="lut_in"/>
+                            <output name="out" num_pins="1" port_class="lut_out"/>
+                                <!-- LUT timing using delay matrix -->
+                                <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                                    we instead take the average of these numbers to get more stable results
+                                    82e-12
+                                    173e-12
+                                    261e-12
+                                    263e-12
+                                    398e-12
+                                    397e-12
+                                -->
+                            <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                                261e-12
+                                261e-12
+                                261e-12
+                                261e-12
+                            </delay_matrix>
+                        </pb_type>
+                        <!-- Define flip-flop -->
+                        <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                            <input name="D" num_pins="1" port_class="D"/>
+                            <output name="Q" num_pins="1" port_class="Q"/>
+                            <clock name="clk" num_pins="1" port_class="clock"/>
+                            <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                            <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+                        </pb_type>
+                        <interconnect>
+                            <direct name="direct1" input="ble4.in" output="lut4[0:0].in"/>
+                            <direct name="direct2" input="lut4.out" output="ff.D">
+                                <!-- Advanced user option that tells CAD tool to find LUT+FF pairs in netlist -->
+                                <pack_pattern name="ble4" in_port="lut4.out" out_port="ff.D"/>
+                            </direct>
+                            <direct name="direct3" input="ble4.clk" output="ff.clk"/>
+                            <mux name="mux1" input="ff.Q lut4.out" output="ble4.out">
+                                <!-- LUT to output is faster than FF to output on a Stratix IV -->
+                                <delay_constant max="25e-12" in_port="lut4.out" out_port="ble4.out"/>
+                                <delay_constant max="45e-12" in_port="ff.Q" out_port="ble4.out"/>
+                            </mux>
+                        </interconnect>
+                    </pb_type>
+                    <interconnect>
+                        <direct name="direct1" input="fle.in" output="ble4.in"/>
+                        <direct name="direct2" input="ble4.out" output="fle.out"/>
+                        <direct name="direct3" input="fle.clk" output="ble4.clk"/>
+                    </interconnect>
+                </mode>
+                <!-- 4-LUT mode definition end -->
+                <!-- Define shift register begin -->
+                <mode name="shift_register" disable_packing="true">
+                    <pb_type name="shift_reg" num_pb="1">
+                        <input name="reg_in" num_pins="1"/>
+                        <output name="ff_out" num_pins="1"/>
+                        <output name="reg_out" num_pins="1"/>
+                        <clock name="clk" num_pins="1"/>
+                        <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                            <input name="D" num_pins="1" port_class="D"/>
+                            <output name="Q" num_pins="1" port_class="Q"/>
+                            <clock name="clk" num_pins="1" port_class="clock"/>
+                            <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                            <T_clock_to_Q max="124e-12" port="ff.Q" clock="clk"/>
+                        </pb_type>
+                        <interconnect>
+                            <direct name="direct1" input="shift_reg.reg_in" output="ff.D"/>
+                            <direct name="direct2" input="ff.Q" output="shift_reg.reg_out"/>
+                            <direct name="direct3" input="ff.Q" output="shift_reg.ff_out"/>
+                            <complete name="complete1" input="shift_reg.clk" output="ff.clk"/>
+                        </interconnect>
+                    </pb_type>
+                    <interconnect>
+                        <direct name="direct1" input="fle.reg_in" output="shift_reg.reg_in"/>
+                        <direct name="direct2" input="shift_reg.reg_out" output="fle.reg_out"/>
+                        <direct name="direct3" input="shift_reg.ff_out" output="fle.out"/>
+                        <direct name="direct4" input="fle.clk" output="shift_reg.clk"/>
+                    </interconnect>
+                </mode>
+                <!-- Define shift register end --> 
             </pb_type>
             <interconnect>
-              <direct name="direct1" input="shift_reg.reg_in" output="ff.D"/>
-              <direct name="direct2" input="ff.Q" output="shift_reg.reg_out"/>
-              <direct name="direct3" input="ff.Q" output="shift_reg.ff_out"/>
-              <complete name="complete1" input="shift_reg.clk" output="ff.clk"/>
-            </interconnect>
-          </pb_type>
-          <interconnect>
-            <direct name="direct1" input="fle.reg_in" output="shift_reg.reg_in"/>
-            <direct name="direct2" input="shift_reg.reg_out" output="fle.reg_out"/>
-            <direct name="direct3" input="shift_reg.ff_out" output="fle.out"/>
-            <direct name="direct4" input="fle.clk" output="shift_reg.clk"/>
-          </interconnect>
-        </mode>
-        <!-- Define shift register end --> 
-      </pb_type>
-      <interconnect>
-        <!-- We use direct connections to reduce the area to the most
-             The global local routing is going to compensate the loss in routability
-          -->
-        <!-- FIXME: The implicit port definition results in I0[0] connected to
+                <!-- We use direct connections to reduce the area to the most
+                    The global local routing is going to compensate the loss in routability
+                -->
+                <!-- FIXME: The implicit port definition results in I0[0] connected to
                     in[2]. Such twisted connection is not expected.
                     I[0] should be connected to in[0]
-	  -->
-	<complete name="crossbar" input="clb.I fle[7:0].out" output="fle[7:0].in">
-          <!-- TODO: Timing should be backannotated from post-PnR results -->
-        </complete>
-        <complete name="clks" input="clb.clk" output="fle[7:0].clk">
-        </complete>
-        <complete name="resets" input="clb.reset" output="fle[7:0].reset">
-        </complete>
-        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
-               By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
-               then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
-               naive specification).
-          -->
-        <direct name="clbouts1" input="fle[3:0].out" output="clb.O[3:0]"/>
-        <direct name="clbouts2" input="fle[7:4].out" output="clb.O[7:4]"/>
-        <!-- Shift register chain links -->
-        <direct name="shift_register_in" input="clb.reg_in" output="fle[0:0].reg_in">
-          <!-- Put all inter-block carry chain delay on this one edge -->
-          <delay_constant max="0.16e-9" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/>
-          <!--pack_pattern name="chain" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/-->
-        </direct>
-        <direct name="shift_register_out" input="fle[7:7].reg_out" output="clb.reg_out">
-          <!--pack_pattern name="chain" in_port="fle[7:7].reg_out" out_port="clb.reg_out"/-->
-        </direct>
-        <direct name="shift_register_link" input="fle[6:0].reg_out" output="fle[7:1].reg_in">
-          <!--pack_pattern name="chain" in_port="fle[6:0].reg_out" out_port="fle[7:1].reg_in"/-->
-        </direct>
-        <!-- Scan chain links -->
-        <direct name="scan_chain_in" input="clb.sc_in" output="fle[0:0].sc_in">
-          <!-- Put all inter-block carry chain delay on this one edge -->
-          <delay_constant max="0.16e-9" in_port="clb.sc_in" out_port="fle[0:0].sc_in"/>
-        </direct>
-        <direct name="scan_chain_out" input="fle[7:7].sc_out" output="clb.sc_out">
-        </direct>
-        <direct name="scan_chain_link" input="fle[6:0].sc_out" output="fle[7:1].sc_in">
-        </direct>
-        <!-- Carry chain links -->
-        <direct name="carry_chain_in" input="clb.cin" output="fle[0:0].cin">
-          <!-- Put all inter-block carry chain delay on this one edge -->
-          <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
-        </direct>
-        <direct name="carry_chain_out" input="fle[7:7].cout" output="clb.cout">
-        </direct>
-        <direct name="carry_chain_link" input="fle[6:0].cout" output="fle[7:1].cin">
-        </direct>
-      </interconnect>
-      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
-      <!-- Place this general purpose logic block in any unspecified column -->
-    </pb_type>
-    <!-- Define general purpose logic block (CLB) ends -->
-  </complexblocklist>
+                -->
+                <complete name="crossbar" input="clb.I fle[7:0].out" output="fle[7:0].in">
+                    <!-- TODO: Timing should be backannotated from post-PnR results -->
+                </complete>
+                <complete name="clks" input="clb.clk" output="fle[7:0].clk">
+                </complete>
+                <complete name="resets" input="clb.reset" output="fle[7:0].reset">
+                </complete>
+                <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+                    By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
+                    then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
+                    naive specification).
+                -->
+                <direct name="clbouts1" input="fle[3:0].out" output="clb.O[3:0]"/>
+                <direct name="clbouts2" input="fle[7:4].out" output="clb.O[7:4]"/>
+                    <!-- Shift register chain links -->
+                <direct name="shift_register_in" input="clb.reg_in" output="fle[0:0].reg_in">
+                    <!-- Put all inter-block carry chain delay on this one edge -->
+                    <delay_constant max="0.16e-9" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/>
+                        <!--pack_pattern name="chain" in_port="clb.reg_in" out_port="fle[0:0].reg_in"/-->
+                </direct>
+                <direct name="shift_register_out" input="fle[7:7].reg_out" output="clb.reg_out">
+                    <!--pack_pattern name="chain" in_port="fle[7:7].reg_out" out_port="clb.reg_out"/-->
+                </direct>
+                <direct name="shift_register_link" input="fle[6:0].reg_out" output="fle[7:1].reg_in">
+                    <!--pack_pattern name="chain" in_port="fle[6:0].reg_out" out_port="fle[7:1].reg_in"/-->
+                </direct>
+                <!-- Scan chain links -->
+                <direct name="scan_chain_in" input="clb.sc_in" output="fle[0:0].sc_in">
+                    <!-- Put all inter-block carry chain delay on this one edge -->
+                    <delay_constant max="0.16e-9" in_port="clb.sc_in" out_port="fle[0:0].sc_in"/>
+                </direct>
+                <direct name="scan_chain_out" input="fle[7:7].sc_out" output="clb.sc_out">
+                </direct>
+                <direct name="scan_chain_link" input="fle[6:0].sc_out" output="fle[7:1].sc_in">
+                </direct>
+                <!-- Carry chain links -->
+                <direct name="carry_chain_in" input="clb.cin" output="fle[0:0].cin">
+                    <!-- Put all inter-block carry chain delay on this one edge -->
+                    <delay_constant max="0.16e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+                </direct>
+                <direct name="carry_chain_out" input="fle[7:7].cout" output="clb.cout">
+                </direct>
+                <direct name="carry_chain_link" input="fle[6:0].cout" output="fle[7:1].cin">
+                </direct>
+            </interconnect>
+            <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+            <!-- Place this general purpose logic block in any unspecified column -->
+        </pb_type>
+        <!-- Define general purpose logic block (CLB) ends -->
+    </complexblocklist>
 </architecture>

--- a/ARCH/vpr_arch/k4_N8_tileable_reset_softadder_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
+++ b/ARCH/vpr_arch/k4_N8_tileable_reset_softadder_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
@@ -33,7 +33,51 @@
         <port name="inpad"/>
       </output_ports>
     </model>
-
+    <model name="in_buff">
+      <input_ports>
+        <port name="A" combinational_sink_ports="Q"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q"/>
+      </output_ports>
+    </model>
+    <model name="in_reg">
+      <input_ports>
+        <port name="clk" is_clock="1"/>
+        <port name="dataIn" clock="clk"/>
+      </input_ports>
+      <output_ports>
+        <port name="dataOut" clock="clk"/>
+      </output_ports>
+    </model>
+    <model name="out_buff">
+      <input_ports>
+        <port combinational_sink_ports="Q" name="A"/>
+      </input_ports>
+      <output_ports>
+        <port name="Q"/>
+      </output_ports>
+    </model>
+    <model name="out_reg">
+      <input_ports>
+        <port name="clk" is_clock="1"/>
+        <port name="dataIn" clock="clk"/>
+      </input_ports>
+      <output_ports>
+        <port name="dataOut" clock="clk"/>
+      </output_ports>
+    </model>
+    <model name="intf_model">
+      <input_ports>
+        <port name="CLK" is_clock="1"/>
+        <port name="SOC_IN" clock="clk"/>
+        <port name="FPGA_OUT" clock="clk"/>
+      </input_ports>
+      <output_ports>
+        <port name="FPGA_IN" clock="clk"/>
+        <port name="SOC_OUT" clock="clk"/>
+      </output_ports>
+    </model>
     <model name="frac_lut4">
       <input_ports>
         <port name="in"/>
@@ -74,49 +118,65 @@
     <!-- Top-side has 1 I/O per tile -->
     <tile name="io_top" capacity="16" area="0">
       <equivalent_sites>
-        <site pb_type="io"/>
+        <site pb_type="interface"/>
       </equivalent_sites>
-      <input name="outpad" num_pins="1"/>
-      <output name="inpad" num_pins="1"/>
+      <clock name="CLK" num_pins="1"/>
+      <input name="SOC_IN" num_pins="1"/>
+      <input name="FPGA_OUT" num_pins="1"/>
+      <output name="FPGA_IN" num_pins="1"/>
+      <output name="SOC_OUT" num_pins="1"/>
       <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
       <pinlocations pattern="custom">
-        <loc side="bottom">io_top.outpad io_top.inpad</loc>
+        <loc side="bottom">io_top.FPGA_IN io_top.FPGA_OUT</loc>
+        <loc side="top">io_top.SOC_IN io_top.SOC_OUT io_top.CLK</loc>
       </pinlocations>
     </tile>
     <!-- Right-side has 1 I/O per tile -->
     <tile name="io_right" capacity="16" area="0">
       <equivalent_sites>
-        <site pb_type="io"/>
+        <site pb_type="interface"/>
       </equivalent_sites>
-      <input name="outpad" num_pins="1"/>
-      <output name="inpad" num_pins="1"/>
+      <clock name="CLK" num_pins="1"/>
+      <input name="SOC_IN" num_pins="1"/>
+      <input name="FPGA_OUT" num_pins="1"/>
+      <output name="FPGA_IN" num_pins="1"/>
+      <output name="SOC_OUT" num_pins="1"/>
       <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
       <pinlocations pattern="custom">
-        <loc side="left">io_right.outpad io_right.inpad</loc>
+        <loc side="bottom">io_right.FPGA_IN io_right.FPGA_OUT</loc>
+        <loc side="top">io_right.SOC_IN io_right.SOC_OUT io_right.CLK</loc>
       </pinlocations>
     </tile>
     <!-- Bottom-side has 9 I/O per tile -->
     <tile name="io_bottom" capacity="16" area="0">
       <equivalent_sites>
-        <site pb_type="io"/>
+        <site pb_type="interface"/>
       </equivalent_sites>
-      <input name="outpad" num_pins="1"/>
-      <output name="inpad" num_pins="1"/>
+      <clock name="CLK" num_pins="1"/>
+      <input name="SOC_IN" num_pins="1"/>
+      <input name="FPGA_OUT" num_pins="1"/>
+      <output name="FPGA_IN" num_pins="1"/>
+      <output name="SOC_OUT" num_pins="1"/>
       <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
       <pinlocations pattern="custom">
-        <loc side="top">io_bottom.outpad io_bottom.inpad</loc>
+        <loc side="top">io_bottom.FPGA_IN io_bottom.FPGA_OUT</loc>
+        <loc side="bottom">io_bottom.SOC_IN io_bottom.SOC_OUT io_bottom.CLK</loc>
       </pinlocations>
     </tile>
     <!-- Left-side has 1 I/O per tile -->
     <tile name="io_left" capacity="16" area="0">
       <equivalent_sites>
-        <site pb_type="io"/>
+        <site pb_type="interface"/>
       </equivalent_sites>
-      <input name="outpad" num_pins="1"/>
-      <output name="inpad" num_pins="1"/>
+      <clock name="CLK" num_pins="1"/>
+      <input name="SOC_IN" num_pins="1"/>
+      <input name="FPGA_OUT" num_pins="1"/>
+      <output name="FPGA_IN" num_pins="1"/>
+      <output name="SOC_OUT" num_pins="1"/>
       <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
       <pinlocations pattern="custom">
-        <loc side="right">io_left.outpad io_left.inpad</loc>
+        <loc side="right">io_left.FPGA_IN io_left.FPGA_OUT</loc>
+        <loc side="left">io_left.SOC_IN io_left.SOC_OUT io_left.CLK</loc>
       </pinlocations>
     </tile>
     <!-- CLB has most pins on the top and right sides -->
@@ -272,58 +332,147 @@
     <direct name="scan_chain" from_pin="clb.sc_out" to_pin="clb.sc_in" x_offset="0" y_offset="-1" z_offset="0"/>
   </directlist>
   <complexblocklist>
-    <!-- Define input pads begin -->
-    <pb_type name="io">
-      <input name="outpad" num_pins="1"/>
-      <output name="inpad" num_pins="1"/>
-      <!-- Do NOT add clock pins to I/O here!!! VPR does not build clock network in the way that OpenFPGA can support
-           If you need to register the I/O, define clocks in the circuit models
-           These clocks can be handled in back-end
-       -->
-      <!-- A mode denotes the physical implementation of an I/O 
-           This mode will be not packable but is mainly used for fabric verilog generation   
-        -->
+    <!-- Define I/O pads begins -->
+    <pb_type name="interface" num_pins="1">
+      <clock name="CLK" num_pins="1"/>
+      <input name="SOC_IN" num_pins="1"/>
+      <input name="FPGA_OUT" num_pins="1"/>
+      <output name="FPGA_IN" num_pins="1"/>
+      <output name="SOC_OUT" num_pins="1"/>
+      <!-- Physical mode definition begin (physical implementation of the interface) -->
       <mode name="physical" disabled_in_pack="true">
-        <pb_type name="iopad" blif_model=".subckt io" num_pb="1">
-          <input name="outpad" num_pins="1"/>
-          <output name="inpad" num_pins="1"/>
+          <pb_type name="intf_fabric" blif_model=".subckt intf_model" num_pb="1">
+            <clock name="CLK" num_pins="1"/>
+            <input name="SOC_IN" num_pins="1"/>
+            <input name="FPGA_OUT" num_pins="1"/>
+            <output name="FPGA_IN" num_pins="1"/>
+            <output name="SOC_OUT" num_pins="1"/>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="interface.CLK" output="intf_fabric.CLK"/>
+            <direct name="direct2" input="interface.SOC_IN" output="intf_fabric.SOC_IN"/>
+            <direct name="direct3" input="interface.FPGA_OUT" output="intf_fabric.FPGA_OUT"/>
+            <direct name="direct4" input="intf_fabric.FPGA_IN" output="interface.FPGA_IN"/>
+            <direct name="direct5" input="intf_fabric.SOC_OUT" output="interface.SOC_OUT"/>
+          </interconnect>
+      </mode>
+      <!-- Physical mode definition end (physical implementation of the interface) -->
+      <mode name="in_buff">
+        <pb_type name="in_buff" num_pb="1">
+          <clock name="CLK" num_pins="1"/>
+          <input name="SOC_IN" num_pins="1"/>
+          <output name="FPGA_IN" num_pins="1"/>
+          <pb_type blif_model=".input" name="inpad" num_pb="1">
+            <output name="inpad" num_pins="1"/>
+          </pb_type>
+          <pb_type blif_model=".subckt in_buff" name="inst_buff" num_pb="1">
+            <input name="A" num_pins="1"/>
+            <output name="Q" num_pins="1"/>
+            <delay_constant in_port="inst_buff.A" max="1e-10" out_port="inst_buff.Q"/>
+            <!--metadata>
+              <meta name="fasm_features">ISEL</meta>
+            </metadata-->
+          </pb_type>
+          <interconnect>
+            <direct input="inst_buff.Q" name="in_buff-FPGA_IN" output="in_buff.FPGA_IN">
+            <direct input="inpad.inpad" name="inst_buff-A" output="inst_buff.A">
+              <pack_pattern in_port="inpad.inpad" name="pack-IPAD_TO_IBUF" out_port="inst_buff.A"/>
+            </direct>
+          </interconnect>
         </pb_type>
         <interconnect>
-          <direct name="outpad" input="io.outpad" output="iopad.outpad">
-            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="iopad.outpad"/>
-          </direct>
-          <direct name="inpad" input="iopad.inpad" output="io.inpad">
-            <delay_constant max="4.243e-11" in_port="iopad.inpad" out_port="io.inpad"/>
-          </direct>
+          <direct input="in_buff.FPGA_IN" name="interface-FPGA_IN" output="interface.FPGA_IN"/>
+          <direct input="interface.SOC_IN" name="in_buff-SOC_IN" output="in_buff.SOC_IN"/>
+          <direct input="interface.CLK" name="in_buff-CLK" output="in_buff.CLK"/>
         </interconnect>
       </mode>
-
-      <!-- IOs can operate as either inputs or outputs.
-	     Delays below come from Ian Kuon. They are small, so they should be interpreted as
-	     the delays to and from registers in the I/O (and generally I/Os are registered 
-	     today and that is when you timing analyze them.
-	     -->
-      <mode name="inpad">
-        <pb_type name="inpad" blif_model=".input" num_pb="1">
-          <output name="inpad" num_pins="1"/>
+      <mode name="out_buff">
+        <pb_type name="out_buff" num_pb="1">
+          <clock name="CLK" num_pins="1"/>
+          <input name="FPGA_OUT" num_pins="1"/>
+          <output name="SOC_OUT" num_pins="1"/>
+          <pb_type blif_model=".subckt out_buff" name="inst_buff" num_pb="1">
+            <input name="A" num_pins="1"/>
+            <output name="Q" num_pins="1"/>
+            <delay_constant in_port="inst_buff.A" max="1e-10" out_port="inst_buff.Q"/>
+            <!--metadata>
+              <meta name="fasm_features">OSEL</meta>
+            </metadata-->
+          </pb_type>
+          <pb_type blif_model=".output" name="outpad" num_pb="1">
+            <input name="outpad" num_pins="1"/>
+          </pb_type>
+          <interconnect>
+            <direct input="out_buff.FPGA_OUT" name="inst_buff-A" output="inst_buff.A"/>
+            <direct input="inst_buff.Q" name="outpad-outpad" output="outpad.outpad">
+              <pack_pattern in_port="inst_buff.Q" name="pack-OBUF_TO_OPAD" out_port="outpad.outpad"/>
+            </direct>
+          </interconnect>
         </pb_type>
         <interconnect>
-          <direct name="inpad" input="inpad.inpad" output="io.inpad">
-            <delay_constant max="4.243e-11" in_port="inpad.inpad" out_port="io.inpad"/>
-          </direct>
+          <direct input="out_buff.SOC_OUT" name="interface-SOC_OUT" output="interface.SOC_OUT"/>
+          <direct input="interface.CLK" name="out_buff-CLK" output="out_buff.CLK"/>
+          <direct input="interface.FPGA_OUT" name="out_buff-FPGA_OUT" output="out_buff.FPGA_OUT"/>
         </interconnect>
       </mode>
-      <mode name="outpad">
-        <pb_type name="outpad" blif_model=".output" num_pb="1">
-          <input name="outpad" num_pins="1"/>
+      <mode name="in_reg">
+        <pb_type name="in_reg" num_pb="1">
+          <clock name="CLK" num_pins="1"/>
+          <input name="SOC_IN" num_pins="1"/>
+          <output name="FPGA_IN" num_pins="1"/>
+          <pb_type blif_model=".input" name="inpad" num_pb="1">
+            <output name="inpad" num_pins="1"/>
+          </pb_type>
+          <pb_type blif_model=".subckt in_reg" name="inst_reg" num_pb="1">
+            <clock name="clk" num_pins="1"/>
+            <input name="dataIn" num_pins="1"/>
+            <output name="dataOut" num_pins="1"/>
+            <T_setup clock="clk" port="inst_reg.dataIn" value="1e-10"/>
+            <T_clock_to_Q clock="clk" max="1e-10" port="inst_reg.dataOut"/>
+          </pb_type>
+          <interconnect>
+            <direct input="inst_reg.dataOut" name="in_reg-FPGA_IN" output="in_reg.FPGA_IN"/>
+            <direct input="in_reg.CLK" name="inst_reg-clk" output="inst_reg.clk"/>
+            <direct input="inpad.inpad" name="inst_reg-dataIn" output="inst_reg.dataIn">
+              <pack_pattern in_port="inpad.inpad" name="pack-IPAD_TO_IREG" out_port="inst_reg.dataIn"/>
+            </direct>
+          </interconnect>
+          </pb_type>
+          <interconnect>
+          <direct input="in_reg.FPGA_IN" name="interface-FPGA_IN" output="interface.FPGA_IN"/>
+          <direct input="interface.SOC_IN" name="in_reg-SOC_IN" output="in_reg.SOC_IN"/>
+          <direct input="interface.CLK" name="in_reg-CLK" output="in_reg.CLK"/>
+          </interconnect>
+      </mode>
+      <mode name="out_reg">
+        <pb_type name="out_reg" num_pb="1">
+          <clock name="CLK" num_pins="1"/>
+          <input name="FPGA_OUT" num_pins="1"/>
+          <output name="SOC_OUT" num_pins="1"/>
+          <pb_type blif_model=".subckt out_reg" name="inst_reg" num_pb="1">
+            <clock name="clk" num_pins="1"/>
+            <input name="dataIn" num_pins="1"/>
+            <output name="dataOut" num_pins="1"/>
+            <T_setup clock="clk" port="inst_reg.dataIn" value="1e-10"/>
+            <T_clock_to_Q clock="clk" max="1e-10" port="inst_reg.dataOut"/>
+          </pb_type>
+          <pb_type blif_model=".output" name="outpad" num_pb="1">
+            <input name="outpad" num_pins="1"/>
+          </pb_type>
+          <interconnect>
+            <direct input="out_reg.CLK" name="inst_reg-clk" output="inst_reg.clk"/>
+            <direct input="out_reg.FPGA_OUT" name="inst_reg-dataIn" output="inst_reg.dataIn"/>
+            <direct input="inst_reg.dataOut" name="outpad-outpad" output="outpad.outpad">
+              <pack_pattern in_port="inst_reg.dataOut" name="pack-OBUF_TO_OREG" out_port="outpad.outpad"/>
+            </direct>
+          </interconnect>
         </pb_type>
         <interconnect>
-          <direct name="outpad" input="io.outpad" output="outpad.outpad">
-            <delay_constant max="1.394e-11" in_port="io.outpad" out_port="outpad.outpad"/>
-          </direct>
+          <direct input="out_reg.SOC_OUT" name="interface-SOC_OUT" output="interface.SOC_OUT"/>
+          <direct input="interface.CLK" name="out_reg-CLK" output="out_reg.CLK"/>
+          <direct input="interface.FPGA_OUT" name="out_reg-FPGA_OUT" output="out_reg.FPGA_OUT"/>
         </interconnect>
       </mode>
-      <power method="ignore"/>
     </pb_type>
     <!-- Define I/O pads ends -->
     <!-- Define general purpose logic block (CLB) begin -->

--- a/BENCHMARK/io_reg/io_reg.v
+++ b/BENCHMARK/io_reg/io_reg.v
@@ -1,0 +1,22 @@
+module io_reg(clk, in, out);
+
+    input clk;
+    input in;
+    output out;
+    reg out;
+
+    //reg temp;
+
+    always @(posedge clk)
+    begin
+        out <= in;
+    end
+    
+    /*always @(posedge clk)
+    begin
+        out <= temp ;
+    end*/
+    
+endmodule
+
+

--- a/BENCHMARK/io_reg/io_reg_tb.v
+++ b/BENCHMARK/io_reg/io_reg_tb.v
@@ -1,0 +1,21 @@
+module io_reg_tb;
+    
+    reg clk_gen, in_gen;
+    wire out;
+
+    io_reg inst(.clk(clk_gen), .in(in_gen), .out(out));
+
+    initial begin
+        #0 in_gen = 1'b1; clk_gen = 1'b0;
+        #100 in_gen = 1'b0;
+    end
+
+    always begin
+        #10 clk_gen = ~clk_gen;
+    end
+
+    initial begin
+        #5000 $stop;
+    end
+
+endmodule

--- a/SCRIPT/skywater_openfpga_task/k4_N8_reset_softadder_caravel_cc_fdhd_32x32/generate_sdc/config/task_template.conf
+++ b/SCRIPT/skywater_openfpga_task/k4_N8_reset_softadder_caravel_cc_fdhd_32x32/generate_sdc/config/task_template.conf
@@ -32,6 +32,7 @@ bench0=${SKYWATER_OPENFPGA_HOME}/BENCHMARK/and2/and2.v
 
 [SYNTHESIS_PARAM]
 bench0_top = and2
+bench0_yosys=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/quicklogic_yosys_flow_ap3.ys
 
 [SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
 #end_flow_with_test=

--- a/SCRIPT/skywater_openfpga_task/k4_N8_reset_softadder_caravel_cc_fdhd_32x32/generate_testbench/config/task_template.conf
+++ b/SCRIPT/skywater_openfpga_task/k4_N8_reset_softadder_caravel_cc_fdhd_32x32/generate_testbench/config/task_template.conf
@@ -56,9 +56,13 @@ bench22=${SKYWATER_OPENFPGA_HOME}/BENCHMARK/io_tc1/rtl/*.v
 
 [SYNTHESIS_PARAM]
 bench0_top = and2
+bench0_yosys=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/quicklogic_yosys_flow_ap3.ys
 bench1_top = and2_latch
+bench1_yosys=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/quicklogic_yosys_flow_ap3.ys
 bench2_top = bin2bcd
+bench2_yosys=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/quicklogic_yosys_flow_ap3.ys
 bench3_top = counter
+bench3_yosys=${PATH:OPENFPGA_PATH}/openfpga_flow/misc/quicklogic_yosys_flow_ap3.ys
 bench4_top = routing_test
 # RS decoder needs 1.5k LUT4, exceeding device capacity
 bench5_top = rs_decoder_top


### PR DESCRIPTION
This adds four modes in interface - in_buff, out_buff, in_reg and out_reg. A new tile named "interface" is added that can function in one of the four interface types.
User needs to instantiate in_reg or out_reg in their Verilog to infer a registered input/output IO. Still need to update yosys to synthesize IO as in_buff or out_buff (by default).