### PR TITLE
Replacing deprecated tile_port syntax

### DIFF
--- a/ARCH/openfpga_arch_template/k4_N8_reset_softadder_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
+++ b/ARCH/openfpga_arch_template/k4_N8_reset_softadder_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
@@ -228,8 +228,12 @@
     <direct name="scan_chain" circuit_model_name="direct_interc" type="column" x_dir="positive" y_dir="positive"/>
   </direct_connection>
   <tile_annotations>
-    <global_port name="clk" tile_port="clb.clk" is_clock="true" default_val="0"/>
-    <global_port name="Reset" tile_port="clb.reset" is_reset="true" default_val="1"/>
+      <global_port name="clk" is_clock="true" default_val="0">
+          <tile name="clb" port="clk" x="-1" y="-1"/>
+      </global_port>
+      <global_port name="Reset" is_reset="true" default_val="1">
+          <tile name="clb" port="reset" x="-1" y="-1"/>
+      </global_port>
   </tile_annotations>
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->

--- a/ARCH/openfpga_arch_template/k4_frac_N8_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
+++ b/ARCH/openfpga_arch_template/k4_frac_N8_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
@@ -216,7 +216,9 @@
     <direct name="scan_chain" circuit_model_name="direct_interc" type="column" x_dir="positive" y_dir="positive"/>
   </direct_connection>
   <tile_annotations>
-    <global_port name="clk" tile_port="clb.clk" is_clock="true" default_val="0"/>
+      <global_port name="clk" is_clock="true" default_val="0">
+          <tile name="clb" port="clk" x="-1" y="-1"/>
+      </global_port>
   </tile_annotations>
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->

--- a/ARCH/openfpga_arch_template/k4_frac_N8_reset_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
+++ b/ARCH/openfpga_arch_template/k4_frac_N8_reset_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
@@ -217,8 +217,12 @@
     <direct name="scan_chain" circuit_model_name="direct_interc" type="column" x_dir="positive" y_dir="positive"/>
   </direct_connection>
   <tile_annotations>
-    <global_port name="clk" tile_port="clb.clk" is_clock="true" default_val="0"/>
-    <global_port name="reset" tile_port="clb.reset" is_reset="true" default_val="1"/>
+      <global_port name="clk" is_clock="true" default_val="0">
+          <tile name="clb" port="clk" x="-1" y="-1"/>
+      </global_port>
+      <global_port name="Reset" is_reset="true" default_val="1">
+          <tile name="clb" port="reset" x="-1" y="-1"/>
+      </global_port>
   </tile_annotations>
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->

--- a/ARCH/openfpga_arch_template/k4_frac_N8_reset_softadder_register_scan_chain_caravel_io_skywater130nm_customhd_cc_openfpga.xml
+++ b/ARCH/openfpga_arch_template/k4_frac_N8_reset_softadder_register_scan_chain_caravel_io_skywater130nm_customhd_cc_openfpga.xml
@@ -288,8 +288,12 @@
     <direct name="scan_chain" circuit_model_name="direct_interc" type="column" x_dir="positive" y_dir="positive"/>
   </direct_connection>
   <tile_annotations>
-    <global_port name="clk" tile_port="clb.clk" is_clock="true" default_val="0"/>
-    <global_port name="Reset" tile_port="clb.reset" is_reset="true" default_val="1"/>
+      <global_port name="clk" is_clock="true" default_val="0">
+          <tile name="clb" port="clk" x="-1" y="-1"/>
+      </global_port>
+      <global_port name="Reset" is_reset="true" default_val="1">
+          <tile name="clb" port="reset" x="-1" y="-1"/>
+      </global_port>
   </tile_annotations>
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->

--- a/ARCH/openfpga_arch_template/k4_frac_N8_reset_softadder_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
+++ b/ARCH/openfpga_arch_template/k4_frac_N8_reset_softadder_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
@@ -229,8 +229,12 @@
     <direct name="scan_chain" circuit_model_name="direct_interc" type="column" x_dir="positive" y_dir="positive"/>
   </direct_connection>
   <tile_annotations>
-    <global_port name="clk" tile_port="clb.clk" is_clock="true" default_val="0"/>
-    <global_port name="Reset" tile_port="clb.reset" is_reset="true" default_val="1"/>
+      <global_port name="clk" is_clock="true" default_val="0">
+          <tile name="clb" port="clk" x="-1" y="-1"/>
+      </global_port>
+      <global_port name="Reset" is_reset="true" default_val="1">
+          <tile name="clb" port="reset" x="-1" y="-1"/>
+      </global_port>
   </tile_annotations>
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->

--- a/ARCH/openfpga_arch_template/k4_frac_N8_softadder_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
+++ b/ARCH/openfpga_arch_template/k4_frac_N8_softadder_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
@@ -228,7 +228,9 @@
     <direct name="scan_chain" circuit_model_name="direct_interc" type="column" x_dir="positive" y_dir="positive"/>
   </direct_connection>
   <tile_annotations>
-    <global_port name="clk" tile_port="clb.clk" is_clock="true" default_val="0"/>
+      <global_port name="clk" is_clock="true" default_val="0">
+          <tile name="clb" port="clk" x="-1" y="-1"/>
+      </global_port>
   </tile_annotations>
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->

--- a/ARCH/openfpga_arch_template/ql_ap3_8x8_arch_vpr_routing_skywater130nm_fdhd_cc_openfpga.xml
+++ b/ARCH/openfpga_arch_template/ql_ap3_8x8_arch_vpr_routing_skywater130nm_fdhd_cc_openfpga.xml
@@ -214,7 +214,9 @@
     <direct name="adder_carry" circuit_model_name="direct_interc"/>
   </direct_connection>
   <tile_annotations>
-    <global_port name="clk" tile_port="SUPER_LOGIC_CELL.QCK" is_clock="true" default_val="0"/>
+      <global_port name="clk" is_clock="true" default_val="0">
+          <tile name="SUPER_LOGIC_CELL" port="QCK" x="-1" y="-1"/>
+      </global_port>
   </tile_annotations>
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->

--- a/FPGA1212_QLSOFA_HD_PNR/FPGA1212_QLSOFA_HD_task/arch/openfpga_arch.xml
+++ b/FPGA1212_QLSOFA_HD_PNR/FPGA1212_QLSOFA_HD_task/arch/openfpga_arch.xml
@@ -229,8 +229,12 @@
     <direct name="scan_chain" circuit_model_name="direct_interc" type="column" x_dir="positive" y_dir="positive"/>
   </direct_connection>
   <tile_annotations>
-    <global_port name="clk" tile_port="clb.clk" is_clock="true" default_val="0"/>
-    <global_port name="Reset" tile_port="clb.reset" is_reset="true" default_val="1"/>
+      <global_port name="clk" is_clock="true" default_val="0">
+          <tile name=="clb" port="clk" x="-1" y="-1"/>
+      </global_port>
+      <global_port name="Reset" is_reset="true" default_val="1">
+          <tile name=="clb" port="reset" x="-1" y="-1"/>
+      </global_port>
   </tile_annotations>
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->

--- a/FPGA1212_SOFA_CHD_PNR/FPGA1212_SOFA_CHD_task/arch/openfpga_arch.xml
+++ b/FPGA1212_SOFA_CHD_PNR/FPGA1212_SOFA_CHD_task/arch/openfpga_arch.xml
@@ -287,8 +287,12 @@
     <direct name="scan_chain" circuit_model_name="direct_interc" type="column" x_dir="positive" y_dir="positive"/>
   </direct_connection>
   <tile_annotations>
-    <global_port name="clk" tile_port="clb.clk" is_clock="true" default_val="0"/>
-    <global_port name="Reset" tile_port="clb.reset" is_reset="true" default_val="1"/>
+      <global_port name="clk" is_clock="true" default_val="0">
+          <tile name=="clb" port="clk" x="-1" y="-1"/>
+      </global_port>
+      <global_port name="Reset" is_reset="true" default_val="1">
+          <tile name=="clb" port="reset" x="-1" y="-1"/>
+      </global_port>
   </tile_annotations>
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->

--- a/FPGA1212_SOFA_HD_PNR/FPGA1212_SOFA_HD_task/arch/openfpga_arch.xml
+++ b/FPGA1212_SOFA_HD_PNR/FPGA1212_SOFA_HD_task/arch/openfpga_arch.xml
@@ -216,7 +216,9 @@
     <direct name="scan_chain" circuit_model_name="direct_interc" type="column" x_dir="positive" y_dir="positive"/>
   </direct_connection>
   <tile_annotations>
-    <global_port name="clk" tile_port="clb.clk" is_clock="true" default_val="0"/>
+      <global_port name="clk" is_clock="true" default_val="0">
+          <tile name=="clb" port="clk" x="-1" y="-1"/>
+      </global_port>
   </tile_annotations>
   <pb_type_annotations>
     <!-- physical pb_type binding in complex block IO -->


### PR DESCRIPTION
With these changes quick_test.sh tests are passing now.