### PR TITLE
Commented out shift_register mode in k4_N8 VPR architecture.

### DIFF
--- a/ARCH/vpr_arch/k4_N8_tileable_reset_softadder_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
+++ b/ARCH/vpr_arch/k4_N8_tileable_reset_softadder_register_scan_chain_nonLR_caravel_io_skywater130nm.xml
@@ -630,6 +630,18 @@ Authors: Xifan Tang
         </mode>
         <!-- 4-LUT mode definition end -->
         <!-- Define shift register begin -->
+
+        <!-- FIXME: Presence of a disabled mode with .latch site inside sometimes triggers
+             the VPR bug: https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1655
+
+             FIXME: There is a bug in the following mode which prevents the
+             first register input from reaching the regular routing network.
+
+             Once both issues are fixed then the mode may be uncommented (and
+             enabled).
+        -->
+
+        <!--
         <mode name="shift_register" disable_packing="true">
           <pb_type name="shift_reg" num_pb="1">
             <input name="reg_in" num_pins="1"/>
@@ -657,6 +669,7 @@ Authors: Xifan Tang
             <direct name="direct4" input="fle.clk" output="shift_reg.clk"/>
           </interconnect>
         </mode>
+        -->
         <!-- Define shift register end --> 
       </pb_type>
       <interconnect>


### PR DESCRIPTION
This PR permanently disabled the `shift_register` mode in k4_N8 VPR architecture plus adds a comment why and what should be done for the mode to be uncommented again.