### PR TITLE
Fix parsing error in FPGA1212_QLSOFA arch file.

### DIFF
--- a/FPGA1212_QLSOFA_HD_PNR/FPGA1212_QLSOFA_HD_task/arch/openfpga_arch.xml
+++ b/FPGA1212_QLSOFA_HD_PNR/FPGA1212_QLSOFA_HD_task/arch/openfpga_arch.xml
@@ -230,10 +230,10 @@
   </direct_connection>
   <tile_annotations>
       <global_port name="clk" is_clock="true" default_val="0">
-          <tile name=="clb" port="clk" x="-1" y="-1"/>
+          <tile name="clb" port="clk" x="-1" y="-1"/>
       </global_port>
       <global_port name="Reset" is_reset="true" default_val="1">
-          <tile name=="clb" port="reset" x="-1" y="-1"/>
+          <tile name="clb" port="reset" x="-1" y="-1"/>
       </global_port>
   </tile_annotations>
   <pb_type_annotations>


### PR DESCRIPTION
I was pointed to this task as a starting point for generating an FPGA on the skywater PDK, and I think this small change is necessary to get the task to run with:

`python3 openfpga_flow/scripts/run_fpga_task.py FPGA1212_QLSOFA_HD_PNR/FPGA1212_QLSOFA_HD_task/`